### PR TITLE
Implement deployment isolation for monorepo apps

### DIFF
--- a/.github/workflows/ci-creai.yml
+++ b/.github/workflows/ci-creai.yml
@@ -1,0 +1,57 @@
+name: CI — CREAI
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'apps/creai/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'apps/creai/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+
+concurrency:
+  group: ci-creai-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test CREAI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint --filter=@unanima/creai
+
+      - name: Build
+        run: pnpm build --filter=@unanima/creai
+
+      - name: Test
+        run: pnpm test --filter=@unanima/creai

--- a/.github/workflows/ci-links.yml
+++ b/.github/workflows/ci-links.yml
@@ -1,0 +1,57 @@
+name: CI — Links
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'apps/links/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'apps/links/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+
+concurrency:
+  group: ci-links-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint --filter=@unanima/links
+
+      - name: Build
+        run: pnpm build --filter=@unanima/links
+
+      - name: Test
+        run: pnpm test --filter=@unanima/links

--- a/.github/workflows/ci-omega.yml
+++ b/.github/workflows/ci-omega.yml
@@ -1,0 +1,57 @@
+name: CI — Omega
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'apps/omega/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'apps/omega/**'
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'turbo.json'
+
+concurrency:
+  group: ci-omega-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test Omega
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint --filter=@unanima/omega
+
+      - name: Build
+        run: pnpm build --filter=@unanima/omega
+
+      - name: Test
+        run: pnpm test --filter=@unanima/omega

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -1,0 +1,55 @@
+name: CI — Packages (socle commun)
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.base.json'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'packages/**'
+      - 'tooling/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.base.json'
+
+concurrency:
+  group: ci-packages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test-all:
+    name: Build & Test all packages and apps
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [links, creai, omega]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint ${{ matrix.app }}
+        run: pnpm lint --filter=@unanima/${{ matrix.app }}
+
+      - name: Build ${{ matrix.app }}
+        run: pnpm build --filter=@unanima/${{ matrix.app }}
+
+      - name: Test ${{ matrix.app }}
+        run: pnpm test --filter=@unanima/${{ matrix.app }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,68 @@ Le script :
 
 ---
 
+## Isolation des déploiements
+
+Chaque application est déployée **indépendamment** sur Vercel. Un échec de build ou de déploiement d'une app ne doit jamais impacter les autres.
+
+### Architecture d'isolation
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │           GitHub (monorepo)              │
+                    │                                         │
+                    │  push sur apps/links/** ───► CI Links   │
+                    │  push sur apps/creai/** ───► CI CREAI   │
+                    │  push sur apps/omega/** ───► CI Omega   │
+                    │  push sur packages/**   ───► CI toutes  │
+                    └─────────────────────────────────────────┘
+                                    │
+                    ┌───────────────┼───────────────┐
+                    ▼               ▼               ▼
+             Vercel Project    Vercel Project   Vercel Project
+               (links)          (creai)          (omega)
+             ignoreCommand    ignoreCommand    ignoreCommand
+               isolé            isolé            isolé
+```
+
+### Mécanismes en place
+
+1. **Vercel `ignoreCommand`** — Chaque `vercel.json` contient un `ignoreCommand` qui appelle `scripts/vercel-ignore.sh <app>`. Ce script vérifie si les fichiers pertinents à l'app ont changé ; sinon, le déploiement est ignoré.
+
+2. **Turborepo `--filter`** — Chaque commande de build utilise `--filter=@unanima/<app>` pour ne construire que l'app ciblée et ses dépendances.
+
+3. **GitHub Actions séparés** — Un workflow CI par app (`.github/workflows/ci-links.yml`, etc.) avec filtrage `paths:` pour ne s'exécuter que sur les changements pertinents. Le workflow `ci-packages.yml` teste les 3 apps en parallèle (`fail-fast: false`) quand le socle change.
+
+4. **Health endpoints** — Chaque app expose `GET /api/health` pour une supervision indépendante.
+
+### Projets Vercel
+
+Chaque app doit être configurée comme un **projet Vercel distinct** pointant vers le même dépôt GitHub, avec :
+- **Root Directory** : `apps/links` (ou `apps/creai`, `apps/omega`)
+- **Framework Preset** : Next.js
+- **Variables d'environnement** : propres à chaque projet (Supabase URL, clés API, etc.)
+
+### Commandes isolées
+
+```bash
+# Build d'une seule app (ne touche pas les autres)
+pnpm build:links
+pnpm build:creai
+pnpm build:omega
+
+# Tests d'une seule app
+pnpm test:links
+pnpm test:creai
+pnpm test:omega
+
+# Dev d'une seule app
+pnpm dev:links
+pnpm dev:creai
+pnpm dev:omega
+```
+
+---
+
 ## Règles strictes
 
 1. **Ne jamais importer de code d'une app vers une autre** — les apps sont isolées
@@ -364,6 +426,8 @@ Le script :
 4. **Les migrations SQL du socle ne doivent jamais être modifiées après déploiement** — créer une nouvelle migration
 5. **Chaque PR qui touche un package du socle doit passer les tests des 3 apps**
 6. **Le CLAUDE.md doit être mis à jour à chaque changement structurel**
+7. **Chaque app doit être un projet Vercel distinct** — jamais de déploiement groupé
+8. **Ne jamais supprimer l'`ignoreCommand` d'un `vercel.json`** — il garantit l'isolation des déploiements
 
 ---
 

--- a/apps/creai/CLAUDE.md
+++ b/apps/creai/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md — creai
+
+## Vue d'ensemble
+Application extranet basée sur le socle Unanima.
+
+## Structure
+```
+src/
+├── app/          ← App Router Next.js
+├── config/       ← Configuration (auth, etc.)
+├── lib/          ← Logique métier spécifique
+└── styles/       ← Thème CSS
+```
+
+## Rôles et permissions
+Voir `src/config/auth.config.ts`

--- a/apps/creai/next.config.js
+++ b/apps/creai/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: [
+    '@unanima/core',
+    '@unanima/auth',
+    '@unanima/dashboard',
+    '@unanima/db',
+    '@unanima/email',
+    '@unanima/rgpd',
+  ],
+}
+
+module.exports = nextConfig

--- a/apps/creai/package.json
+++ b/apps/creai/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@unanima/creai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@unanima/auth": "workspace:*",
+    "@unanima/core": "workspace:*",
+    "@unanima/dashboard": "workspace:*",
+    "@unanima/db": "workspace:*",
+    "@unanima/email": "workspace:*",
+    "@unanima/rgpd": "workspace:*",
+    "next": "^14.2.23",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@unanima/eslint-config": "workspace:*",
+    "@unanima/tailwind-config": "workspace:*",
+    "@unanima/tsconfig": "workspace:*",
+    "typescript": "^5.7.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/apps/creai/src/app/api/health/route.ts
+++ b/apps/creai/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    app: 'creai',
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/apps/creai/src/app/layout.tsx
+++ b/apps/creai/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+import '../styles/theme.css'
+
+export const metadata: Metadata = {
+  title: 'Unanima',
+  description: 'Application Unanima',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="fr">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/creai/src/app/page.tsx
+++ b/apps/creai/src/app/page.tsx
@@ -1,0 +1,9 @@
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-3xl font-bold text-[var(--color-primary)]">
+        Bienvenue
+      </h1>
+    </main>
+  )
+}

--- a/apps/creai/src/config/auth.config.ts
+++ b/apps/creai/src/config/auth.config.ts
@@ -1,0 +1,15 @@
+import type { AuthConfig } from '@unanima/auth'
+
+export const authConfig: AuthConfig = {
+  roles: ['admin', 'user'],
+  defaultRole: 'user',
+  redirects: {
+    afterLogin: '/dashboard',
+    afterLogout: '/login',
+    unauthorized: '/login',
+  },
+  permissions: {
+    admin: ['*'],
+    user: ['read:own', 'write:own'],
+  },
+}

--- a/apps/creai/src/styles/theme.css
+++ b/apps/creai/src/styles/theme.css
@@ -1,0 +1,12 @@
+:root {
+  --color-primary: #1E6FC0;
+  --color-primary-dark: #0D3B6E;
+  --color-success: #28A745;
+  --color-warning: #FF6B35;
+  --color-danger: #DC3545;
+  --color-info: #17A2B8;
+  --color-background: #F5F7FA;
+  --color-text: #4A4A4A;
+  --color-border: #DCE1EB;
+  --font-family: 'Inter', sans-serif;
+}

--- a/apps/creai/tsconfig.json
+++ b/apps/creai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", ".next"]
+}

--- a/apps/creai/vercel.json
+++ b/apps/creai/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm build --filter=@unanima/creai",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh creai"
+}

--- a/apps/links/CLAUDE.md
+++ b/apps/links/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md — links
+
+## Vue d'ensemble
+Application extranet basée sur le socle Unanima.
+
+## Structure
+```
+src/
+├── app/          ← App Router Next.js
+├── config/       ← Configuration (auth, etc.)
+├── lib/          ← Logique métier spécifique
+└── styles/       ← Thème CSS
+```
+
+## Rôles et permissions
+Voir `src/config/auth.config.ts`

--- a/apps/links/next.config.js
+++ b/apps/links/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: [
+    '@unanima/core',
+    '@unanima/auth',
+    '@unanima/dashboard',
+    '@unanima/db',
+    '@unanima/email',
+    '@unanima/rgpd',
+  ],
+}
+
+module.exports = nextConfig

--- a/apps/links/package.json
+++ b/apps/links/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@unanima/links",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@unanima/auth": "workspace:*",
+    "@unanima/core": "workspace:*",
+    "@unanima/dashboard": "workspace:*",
+    "@unanima/db": "workspace:*",
+    "@unanima/email": "workspace:*",
+    "@unanima/rgpd": "workspace:*",
+    "next": "^14.2.23",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@unanima/eslint-config": "workspace:*",
+    "@unanima/tailwind-config": "workspace:*",
+    "@unanima/tsconfig": "workspace:*",
+    "typescript": "^5.7.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/apps/links/src/app/api/health/route.ts
+++ b/apps/links/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    app: 'links',
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/apps/links/src/app/layout.tsx
+++ b/apps/links/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+import '../styles/theme.css'
+
+export const metadata: Metadata = {
+  title: 'Unanima',
+  description: 'Application Unanima',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="fr">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/links/src/app/page.tsx
+++ b/apps/links/src/app/page.tsx
@@ -1,0 +1,9 @@
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-3xl font-bold text-[var(--color-primary)]">
+        Bienvenue
+      </h1>
+    </main>
+  )
+}

--- a/apps/links/src/config/auth.config.ts
+++ b/apps/links/src/config/auth.config.ts
@@ -1,0 +1,15 @@
+import type { AuthConfig } from '@unanima/auth'
+
+export const authConfig: AuthConfig = {
+  roles: ['admin', 'user'],
+  defaultRole: 'user',
+  redirects: {
+    afterLogin: '/dashboard',
+    afterLogout: '/login',
+    unauthorized: '/login',
+  },
+  permissions: {
+    admin: ['*'],
+    user: ['read:own', 'write:own'],
+  },
+}

--- a/apps/links/src/styles/theme.css
+++ b/apps/links/src/styles/theme.css
@@ -1,0 +1,12 @@
+:root {
+  --color-primary: #1E6FC0;
+  --color-primary-dark: #0D3B6E;
+  --color-success: #28A745;
+  --color-warning: #FF6B35;
+  --color-danger: #DC3545;
+  --color-info: #17A2B8;
+  --color-background: #F5F7FA;
+  --color-text: #4A4A4A;
+  --color-border: #DCE1EB;
+  --font-family: 'Inter', sans-serif;
+}

--- a/apps/links/tsconfig.json
+++ b/apps/links/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", ".next"]
+}

--- a/apps/links/vercel.json
+++ b/apps/links/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm build --filter=@unanima/links",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh links"
+}

--- a/apps/omega/CLAUDE.md
+++ b/apps/omega/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md — omega
+
+## Vue d'ensemble
+Application extranet basée sur le socle Unanima.
+
+## Structure
+```
+src/
+├── app/          ← App Router Next.js
+├── config/       ← Configuration (auth, etc.)
+├── lib/          ← Logique métier spécifique
+└── styles/       ← Thème CSS
+```
+
+## Rôles et permissions
+Voir `src/config/auth.config.ts`

--- a/apps/omega/next.config.js
+++ b/apps/omega/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: [
+    '@unanima/core',
+    '@unanima/auth',
+    '@unanima/dashboard',
+    '@unanima/db',
+    '@unanima/email',
+    '@unanima/rgpd',
+  ],
+}
+
+module.exports = nextConfig

--- a/apps/omega/package.json
+++ b/apps/omega/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@unanima/omega",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@unanima/auth": "workspace:*",
+    "@unanima/core": "workspace:*",
+    "@unanima/dashboard": "workspace:*",
+    "@unanima/db": "workspace:*",
+    "@unanima/email": "workspace:*",
+    "@unanima/rgpd": "workspace:*",
+    "next": "^14.2.23",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@unanima/eslint-config": "workspace:*",
+    "@unanima/tailwind-config": "workspace:*",
+    "@unanima/tsconfig": "workspace:*",
+    "typescript": "^5.7.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/apps/omega/src/app/api/health/route.ts
+++ b/apps/omega/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    app: 'omega',
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/apps/omega/src/app/layout.tsx
+++ b/apps/omega/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+import '../styles/theme.css'
+
+export const metadata: Metadata = {
+  title: 'Unanima',
+  description: 'Application Unanima',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="fr">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/omega/src/app/page.tsx
+++ b/apps/omega/src/app/page.tsx
@@ -1,0 +1,9 @@
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-3xl font-bold text-[var(--color-primary)]">
+        Bienvenue
+      </h1>
+    </main>
+  )
+}

--- a/apps/omega/src/config/auth.config.ts
+++ b/apps/omega/src/config/auth.config.ts
@@ -1,0 +1,15 @@
+import type { AuthConfig } from '@unanima/auth'
+
+export const authConfig: AuthConfig = {
+  roles: ['admin', 'user'],
+  defaultRole: 'user',
+  redirects: {
+    afterLogin: '/dashboard',
+    afterLogout: '/login',
+    unauthorized: '/login',
+  },
+  permissions: {
+    admin: ['*'],
+    user: ['read:own', 'write:own'],
+  },
+}

--- a/apps/omega/src/styles/theme.css
+++ b/apps/omega/src/styles/theme.css
@@ -1,0 +1,12 @@
+:root {
+  --color-primary: #1E6FC0;
+  --color-primary-dark: #0D3B6E;
+  --color-success: #28A745;
+  --color-warning: #FF6B35;
+  --color-danger: #DC3545;
+  --color-info: #17A2B8;
+  --color-background: #F5F7FA;
+  --color-text: #4A4A4A;
+  --color-border: #DCE1EB;
+  --font-family: 'Inter', sans-serif;
+}

--- a/apps/omega/tsconfig.json
+++ b/apps/omega/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", ".next"]
+}

--- a/apps/omega/vercel.json
+++ b/apps/omega/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm build --filter=@unanima/omega",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh omega"
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",
+    "dev:links": "turbo run dev --filter=@unanima/links",
+    "dev:creai": "turbo run dev --filter=@unanima/creai",
+    "dev:omega": "turbo run dev --filter=@unanima/omega",
+    "build:links": "turbo run build --filter=@unanima/links",
+    "build:creai": "turbo run build --filter=@unanima/creai",
+    "build:omega": "turbo run build --filter=@unanima/omega",
+    "test:links": "turbo run test --filter=@unanima/links",
+    "test:creai": "turbo run test --filter=@unanima/creai",
+    "test:omega": "turbo run test --filter=@unanima/omega",
+    "lint:links": "turbo run lint --filter=@unanima/links",
+    "lint:creai": "turbo run lint --filter=@unanima/creai",
+    "lint:omega": "turbo run lint --filter=@unanima/omega",
     "generate:types": "./scripts/generate-types.sh"
   },
   "devDependencies": {

--- a/scripts/new-app.sh
+++ b/scripts/new-app.sh
@@ -76,12 +76,13 @@ const nextConfig = {
 module.exports = nextConfig
 EOF
 
-# vercel.json
+# vercel.json — includes ignoreCommand for deployment isolation
 cat > "${APP_DIR}/vercel.json" << EOF
 {
   "framework": "nextjs",
   "installCommand": "pnpm install",
-  "buildCommand": "pnpm build --filter=@unanima/${APP_NAME}"
+  "buildCommand": "pnpm build --filter=@unanima/${APP_NAME}",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh ${APP_NAME}"
 }
 EOF
 
@@ -133,6 +134,20 @@ cat > "${APP_DIR}/src/styles/theme.css" << 'EOF'
   --color-text: #4A4A4A;
   --color-border: #DCE1EB;
   --font-family: 'Inter', sans-serif;
+}
+EOF
+
+# Health endpoint for independent monitoring
+mkdir -p "${APP_DIR}/src/app/api/health"
+cat > "${APP_DIR}/src/app/api/health/route.ts" << EOF
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    app: '${APP_NAME}',
+    timestamp: new Date().toISOString(),
+  })
 }
 EOF
 

--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# vercel-ignore.sh — Determines whether a Vercel deployment should proceed.
+#
+# Vercel calls this script via the "ignoreCommand" in vercel.json.
+# Exit code 0 = skip deploy (no relevant changes)
+# Exit code 1 = proceed with deploy (changes detected)
+#
+# Usage: ./scripts/vercel-ignore.sh <app-name>
+#
+# This ensures that a deployment failure or code change in one app
+# does NOT trigger redeployment of another app.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <app-name>"
+  exit 1
+fi
+
+APP_NAME="$1"
+APP_DIR="apps/${APP_NAME}"
+
+echo "Checking for changes relevant to app '${APP_NAME}'..."
+
+# Directories that, if changed, should trigger a rebuild of this app
+WATCHED_PATHS=(
+  "${APP_DIR}"
+  "packages/core"
+  "packages/auth"
+  "packages/dashboard"
+  "packages/db"
+  "packages/email"
+  "packages/rgpd"
+  "tooling"
+  "package.json"
+  "pnpm-lock.yaml"
+  "pnpm-workspace.yaml"
+  "tsconfig.base.json"
+)
+
+# Use Vercel's VERCEL_GIT_PREVIOUS_SHA if available, otherwise compare with HEAD~1
+PREVIOUS_SHA="${VERCEL_GIT_PREVIOUS_SHA:-HEAD~1}"
+
+for path in "${WATCHED_PATHS[@]}"; do
+  if git diff --quiet "${PREVIOUS_SHA}" HEAD -- "${path}" 2>/dev/null; then
+    continue
+  else
+    echo "Changes detected in '${path}' — proceeding with deployment of '${APP_NAME}'."
+    exit 1
+  fi
+done
+
+echo "No relevant changes for app '${APP_NAME}' — skipping deployment."
+exit 0

--- a/turbo.json
+++ b/turbo.json
@@ -3,17 +3,35 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**"],
+      "inputs": ["src/**", "package.json", "tsconfig.json", "next.config.js"]
     },
     "dev": {
       "cache": false,
       "persistent": true
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "inputs": ["src/**", "tests/**", "vitest.config.*"]
     },
     "lint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", ".eslintrc.*"]
+    },
+    "build:links": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**"],
+      "inputs": ["src/**", "package.json", "tsconfig.json", "next.config.js"]
+    },
+    "build:creai": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**"],
+      "inputs": ["src/**", "package.json", "tsconfig.json", "next.config.js"]
+    },
+    "build:omega": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**"],
+      "inputs": ["src/**", "package.json", "tsconfig.json", "next.config.js"]
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR establishes complete deployment isolation for the three applications (Links, CREAI, Omega) in the monorepo, ensuring that build failures or code changes in one app do not impact the deployment of others.

## Key Changes

### Deployment Isolation Infrastructure
- **Vercel `ignoreCommand` script** (`scripts/vercel-ignore.sh`): Intelligently skips deployments when only unrelated app code changes, preventing unnecessary rebuilds
- **Per-app Vercel configuration** (`vercel.json` in each app): Each app now has its own Vercel project configuration with isolated build commands and ignore logic
- **Separate GitHub Actions workflows**: 
  - `ci-links.yml`, `ci-creai.yml`, `ci-omega.yml` — Run independently when their respective app code changes
  - `ci-packages.yml` — Tests all three apps in parallel (`fail-fast: false`) when shared packages change

### Application Scaffolding
- **Complete app structure** for Links, CREAI, and Omega:
  - `package.json` with isolated dependencies and scripts
  - `next.config.js` with proper transpilation of shared packages
  - `tsconfig.json` extending base configuration
  - `CLAUDE.md` with app-specific documentation
  - Auth configuration (`src/config/auth.config.ts`)
  - Health endpoint (`src/app/api/health/route.ts`) for independent monitoring
  - Basic layout and home page

### Build System Updates
- **Turborepo configuration** (`turbo.json`):
  - Added app-specific build tasks (`build:links`, `build:creai`, `build:omega`)
  - Configured proper inputs/outputs for caching
  - Added test and lint task dependencies
- **Root package.json scripts**: Added isolated dev, build, test, and lint commands for each app

### Documentation
- **CLAUDE.md** updated with comprehensive "Isolation des déploiements" section explaining:
  - Architecture diagram showing independent CI/CD pipelines
  - Four isolation mechanisms (Vercel ignoreCommand, Turborepo filtering, GitHub Actions, health endpoints)
  - Vercel project configuration requirements
  - Isolated command examples
  - Two new strict rules enforcing deployment isolation

## Implementation Details
- Each app is configured as a **distinct Vercel project** pointing to the same GitHub repository with its own root directory
- The `ignoreCommand` script monitors changes in app-specific directories and shared packages, exiting with code 0 (skip) or 1 (deploy)
- GitHub Actions use `paths:` filtering to trigger only relevant workflows, reducing unnecessary CI runs
- All three apps share the same base configuration and styling system while maintaining complete independence

https://claude.ai/code/session_01BuHtVXnbbyw29RWtdn33YB