### PR TITLE
fix(core,auth,dashboard): design system, DRY, robustesse et accessibilité

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@supabase/ssr": "^0.5.2",
-    "@supabase/supabase-js": "^2.48.1"
+    "@supabase/supabase-js": "^2.48.1",
+    "@unanima/core": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",

--- a/packages/auth/src/components/login-form.tsx
+++ b/packages/auth/src/components/login-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, type FormEvent } from 'react'
+import { Button, Input } from '@unanima/core'
 import { useAuth } from '../hooks'
 
 interface LoginFormProps {
@@ -31,58 +32,38 @@ export function LoginForm({ onResetPassword, className }: LoginFormProps) {
   return (
     <form onSubmit={handleSubmit} className={className}>
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="login-email" className="text-sm font-medium text-[var(--color-text)]">
-            E-mail
-          </label>
-          <input
-            id="login-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoComplete="email"
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
-          />
-        </div>
-
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="login-password" className="text-sm font-medium text-[var(--color-text)]">
-            Mot de passe
-          </label>
-          <input
-            id="login-password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="current-password"
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
-          />
-        </div>
-
         {error && (
           <p className="text-sm text-[var(--color-danger)]" role="alert">
             {error}
           </p>
         )}
 
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="w-full rounded-md bg-[var(--color-primary)] px-4 py-2 text-white hover:bg-[var(--color-primary-dark)] disabled:opacity-50 transition-colors"
-        >
-          {isSubmitting ? 'Connexion…' : 'Se connecter'}
-        </button>
+        <Input
+          variant="email"
+          label="Adresse e-mail"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+        />
+
+        <Input
+          variant="password"
+          label="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoComplete="current-password"
+        />
+
+        <Button variant="primary" size="lg" loading={isSubmitting} className="w-full">
+          Se connecter
+        </Button>
 
         {onResetPassword && (
-          <button
-            type="button"
-            onClick={onResetPassword}
-            className="text-sm text-[var(--color-primary)] hover:underline"
-          >
+          <Button variant="ghost" size="sm" type="button" onClick={onResetPassword}>
             Mot de passe oublié ?
-          </button>
+          </Button>
         )}
       </div>
     </form>

--- a/packages/auth/src/components/reset-password-form.tsx
+++ b/packages/auth/src/components/reset-password-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, type FormEvent } from 'react'
+import { Button, Input, Card } from '@unanima/core'
 import { useAuth } from '../hooks'
 
 interface ResetPasswordFormProps {
@@ -32,63 +33,45 @@ export function ResetPasswordForm({ onBack, className }: ResetPasswordFormProps)
 
   if (success) {
     return (
-      <div className={className}>
+      <Card className={className}>
         <p className="text-[var(--color-text)]">
           Un e-mail de réinitialisation a été envoyé à <strong>{email}</strong>.
         </p>
         {onBack && (
-          <button
-            type="button"
-            onClick={onBack}
-            className="mt-4 text-sm text-[var(--color-primary)] hover:underline"
-          >
+          <Button variant="ghost" size="sm" type="button" onClick={onBack} className="mt-4">
             Retour à la connexion
-          </button>
+          </Button>
         )}
-      </div>
+      </Card>
     )
   }
 
   return (
     <form onSubmit={handleSubmit} className={className}>
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="reset-email" className="text-sm font-medium text-[var(--color-text)]">
-            E-mail
-          </label>
-          <input
-            id="reset-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoComplete="email"
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
-          />
-        </div>
-
         {error && (
           <p className="text-sm text-[var(--color-danger)]" role="alert">
             {error}
           </p>
         )}
 
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="w-full rounded-md bg-[var(--color-primary)] px-4 py-2 text-white hover:bg-[var(--color-primary-dark)] disabled:opacity-50 transition-colors"
-        >
-          {isSubmitting ? 'Envoi…' : 'Réinitialiser le mot de passe'}
-        </button>
+        <Input
+          variant="email"
+          label="Adresse e-mail"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+        />
+
+        <Button variant="primary" size="lg" loading={isSubmitting} className="w-full">
+          Réinitialiser le mot de passe
+        </Button>
 
         {onBack && (
-          <button
-            type="button"
-            onClick={onBack}
-            className="text-sm text-[var(--color-primary)] hover:underline"
-          >
+          <Button variant="ghost" size="sm" type="button" onClick={onBack}>
             Retour à la connexion
-          </button>
+          </Button>
         )}
       </div>
     </form>

--- a/packages/core/src/components/button.tsx
+++ b/packages/core/src/components/button.tsx
@@ -73,16 +73,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {loading && (
-          <svg
-            className="h-4 w-4 animate-spin"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
+          <>
+            <svg
+              className="h-4 w-4 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            <span className="sr-only">Chargement en cours</span>
+          </>
         )}
-        {children}
+        <span aria-hidden={loading || undefined}>{children}</span>
       </button>
     )
   },

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -13,9 +13,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "recharts": "^2.15.0",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^2.6.0"
+    "@unanima/core": "workspace:*",
+    "recharts": "^2.15.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",

--- a/packages/dashboard/src/AlertPanel.tsx
+++ b/packages/dashboard/src/AlertPanel.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react'
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface Alert {
   id: string

--- a/packages/dashboard/src/ChartWrapper.tsx
+++ b/packages/dashboard/src/ChartWrapper.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Component, useMemo, type ReactNode } from 'react'
 import {
   BarChart,
   Bar,
@@ -15,7 +16,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface ChartConfig {
   xAxisKey?: string
@@ -33,13 +34,109 @@ export interface ChartWrapperProps {
   className?: string
 }
 
-const DEFAULT_COLORS = [
-  'var(--color-primary)',
-  'var(--color-secondary, var(--color-success))',
-  'var(--color-accent, var(--color-warning))',
-  'var(--color-info)',
-  'var(--color-success)',
+const DEFAULT_CSS_COLORS = [
+  '--color-primary',
+  '--color-secondary',
+  '--color-accent',
+  '--color-info',
+  '--color-success',
 ]
+
+const FALLBACK_COLORS = [
+  '#1E6FC0',
+  '#28A745',
+  '#FF6B35',
+  '#17A2B8',
+  '#28A745',
+]
+
+function resolveColor(cssVar: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback
+  const resolved = getComputedStyle(document.documentElement).getPropertyValue(cssVar).trim()
+  return resolved || fallback
+}
+
+function useResolvedColors(cssVars: string[], fallbacks: string[]): string[] {
+  return useMemo(
+    () => cssVars.map((v, i) => resolveColor(v, fallbacks[i] ?? '#1E6FC0')),
+    [cssVars, fallbacks],
+  )
+}
+
+function EmptyState({ height }: { height: number }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-3"
+      style={{ height }}
+    >
+      <svg
+        className="h-12 w-12 text-[var(--color-text-muted,var(--color-text))]/40"
+        fill="none"
+        viewBox="0 0 48 48"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        aria-hidden="true"
+      >
+        <rect x="6" y="20" width="8" height="20" rx="1" />
+        <rect x="20" y="12" width="8" height="28" rx="1" />
+        <rect x="34" y="24" width="8" height="16" rx="1" />
+        <line x1="4" y1="44" x2="44" y2="44" strokeLinecap="round" />
+        <line x1="2" y1="2" x2="46" y2="46" strokeWidth={2} strokeLinecap="round" />
+      </svg>
+      <p className="text-sm text-[var(--color-text-muted,var(--color-text))]/60">
+        Aucune donnée à afficher
+      </p>
+    </div>
+  )
+}
+
+interface ChartErrorBoundaryProps {
+  children: ReactNode
+  height: number
+}
+
+interface ChartErrorBoundaryState {
+  hasError: boolean
+}
+
+class ChartErrorBoundary extends Component<ChartErrorBoundaryProps, ChartErrorBoundaryState> {
+  constructor(props: ChartErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ChartErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('[ChartWrapper] Erreur de rendu du graphique :', error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          className="flex flex-col items-center justify-center gap-3"
+          style={{ height: this.props.height }}
+        >
+          <p className="text-sm text-[var(--color-danger)]">
+            Erreur d'affichage du graphique
+          </p>
+          <button
+            type="button"
+            onClick={() => this.setState({ hasError: false })}
+            className="rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-sm text-white hover:bg-[var(--color-primary-dark)] transition-colors"
+          >
+            Réessayer
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
 
 export function ChartWrapper({
   type,
@@ -51,10 +148,17 @@ export function ChartWrapper({
   const {
     xAxisKey = 'name',
     yAxisKey = 'value',
-    colors = DEFAULT_COLORS,
+    colors: configColors,
     showLegend = true,
     showGrid = true,
   } = config
+
+  const resolvedColors = useResolvedColors(
+    configColors ?? DEFAULT_CSS_COLORS,
+    configColors ?? FALLBACK_COLORS,
+  )
+
+  const isEmpty = !data || data.length === 0
 
   return (
     <div className={cn(
@@ -64,75 +168,81 @@ export function ChartWrapper({
       'shadow-sm',
       className,
     )}>
-      <ResponsiveContainer width="100%" height={height}>
-        {type === 'bar' ? (
-          <BarChart data={data}>
-            {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />}
-            <XAxis dataKey={xAxisKey} stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
-            <YAxis stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--color-surface, #fff)',
-                border: '1px solid var(--color-border-light, var(--color-border))',
-                borderRadius: 'var(--radius-md, 0.5rem)',
-                boxShadow: 'var(--shadow-lg)',
-              }}
-            />
-            {showLegend && <Legend />}
-            <Bar dataKey={yAxisKey} fill={colors[0]} radius={[6, 6, 0, 0]} />
-          </BarChart>
-        ) : type === 'line' ? (
-          <LineChart data={data}>
-            {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />}
-            <XAxis dataKey={xAxisKey} stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
-            <YAxis stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--color-surface, #fff)',
-                border: '1px solid var(--color-border-light, var(--color-border))',
-                borderRadius: 'var(--radius-md, 0.5rem)',
-                boxShadow: 'var(--shadow-lg)',
-              }}
-            />
-            {showLegend && <Legend />}
-            <Line
-              type="monotone"
-              dataKey={yAxisKey}
-              stroke={colors[0]}
-              strokeWidth={2.5}
-              dot={{ r: 4, strokeWidth: 2, fill: 'var(--color-surface, #fff)' }}
-              activeDot={{ r: 6, strokeWidth: 2 }}
-            />
-          </LineChart>
-        ) : (
-          <PieChart>
-            <Pie
-              data={data}
-              dataKey={yAxisKey}
-              nameKey={xAxisKey}
-              cx="50%"
-              cy="50%"
-              outerRadius={80}
-              innerRadius={40}
-              paddingAngle={3}
-              strokeWidth={0}
-            >
-              {data.map((_, idx) => (
-                <Cell key={idx} fill={colors[idx % colors.length]} />
-              ))}
-            </Pie>
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'var(--color-surface, #fff)',
-                border: '1px solid var(--color-border-light, var(--color-border))',
-                borderRadius: 'var(--radius-md, 0.5rem)',
-                boxShadow: 'var(--shadow-lg)',
-              }}
-            />
-            {showLegend && <Legend />}
-          </PieChart>
-        )}
-      </ResponsiveContainer>
+      {isEmpty ? (
+        <EmptyState height={height} />
+      ) : (
+        <ChartErrorBoundary height={height}>
+          <ResponsiveContainer width="100%" height={height}>
+            {type === 'bar' ? (
+              <BarChart data={data}>
+                {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />}
+                <XAxis dataKey={xAxisKey} stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
+                <YAxis stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'var(--color-surface, #fff)',
+                    border: '1px solid var(--color-border-light, var(--color-border))',
+                    borderRadius: 'var(--radius-md, 0.5rem)',
+                    boxShadow: 'var(--shadow-lg)',
+                  }}
+                />
+                {showLegend && <Legend />}
+                <Bar dataKey={yAxisKey} fill={resolvedColors[0]} radius={[6, 6, 0, 0]} />
+              </BarChart>
+            ) : type === 'line' ? (
+              <LineChart data={data}>
+                {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />}
+                <XAxis dataKey={xAxisKey} stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
+                <YAxis stroke="var(--color-text-muted, var(--color-text))" fontSize={12} />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'var(--color-surface, #fff)',
+                    border: '1px solid var(--color-border-light, var(--color-border))',
+                    borderRadius: 'var(--radius-md, 0.5rem)',
+                    boxShadow: 'var(--shadow-lg)',
+                  }}
+                />
+                {showLegend && <Legend />}
+                <Line
+                  type="monotone"
+                  dataKey={yAxisKey}
+                  stroke={resolvedColors[0]}
+                  strokeWidth={2.5}
+                  dot={{ r: 4, strokeWidth: 2, fill: 'var(--color-surface, #fff)' }}
+                  activeDot={{ r: 6, strokeWidth: 2 }}
+                />
+              </LineChart>
+            ) : (
+              <PieChart>
+                <Pie
+                  data={data}
+                  dataKey={yAxisKey}
+                  nameKey={xAxisKey}
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={80}
+                  innerRadius={40}
+                  paddingAngle={3}
+                  strokeWidth={0}
+                >
+                  {data.map((_, idx) => (
+                    <Cell key={idx} fill={resolvedColors[idx % resolvedColors.length]} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'var(--color-surface, #fff)',
+                    border: '1px solid var(--color-border-light, var(--color-border))',
+                    borderRadius: 'var(--radius-md, 0.5rem)',
+                    boxShadow: 'var(--shadow-lg)',
+                  }}
+                />
+                {showLegend && <Legend />}
+              </PieChart>
+            )}
+          </ResponsiveContainer>
+        </ChartErrorBoundary>
+      )}
     </div>
   )
 }

--- a/packages/dashboard/src/DataTable.tsx
+++ b/packages/dashboard/src/DataTable.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo, type ReactNode } from 'react'
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface ColumnDef<T> {
   key: string

--- a/packages/dashboard/src/KPICard.tsx
+++ b/packages/dashboard/src/KPICard.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react'
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface KPICardProps {
   title: string

--- a/packages/dashboard/src/Layout.tsx
+++ b/packages/dashboard/src/Layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, type ReactNode } from 'react'
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface NavItem {
   label: string

--- a/packages/dashboard/src/ProgressBar.tsx
+++ b/packages/dashboard/src/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface ProgressBarProps {
   value: number

--- a/packages/dashboard/src/SearchBar.tsx
+++ b/packages/dashboard/src/SearchBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface SearchBarProps {
   placeholder?: string

--- a/packages/dashboard/src/StatusBadge.tsx
+++ b/packages/dashboard/src/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { cn } from './cn'
+import { cn } from '@unanima/core'
 
 export interface StatusConfig {
   label: string

--- a/packages/dashboard/src/cn.ts
+++ b/packages/dashboard/src/cn.ts
@@ -1,6 +1,0 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-
-export function cn(...inputs: ClassValue[]): string {
-  return twMerge(clsx(inputs))
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.48.1
         version: 2.99.0
+      '@unanima/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -268,15 +271,12 @@ importers:
 
   packages/dashboard:
     dependencies:
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      '@unanima/core':
+        specifier: workspace:*
+        version: link:../core
       recharts:
         specifier: ^2.15.0
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.1
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -4276,8 +4276,8 @@ snapshots:
       '@typescript-eslint/parser': 8.57.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4296,7 +4296,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4307,22 +4307,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4333,7 +4333,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Résumé

- **#23** : Refactorer `LoginForm` et `ResetPasswordForm` pour utiliser `<Button>`, `<Input>` et `<Card>` de `@unanima/core` au lieu de classes Tailwind inline
- **#24** : Supprimer le doublon `cn()` dans `@unanima/dashboard`, importer depuis `@unanima/core`
- **#25** : `ChartWrapper` — état vide avec message, error boundary avec bouton réessayer, résolution des CSS variables pour Recharts
- **#26** : `Button` loading — `aria-hidden` sur le spinner SVG, `<span sr-only>` pour lecteurs d'écran

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `packages/auth/package.json` | Ajout dépendance `@unanima/core` |
| `packages/auth/src/components/login-form.tsx` | Refactoring avec composants core |
| `packages/auth/src/components/reset-password-form.tsx` | Refactoring avec composants core + Card |
| `packages/core/src/components/button.tsx` | Accessibilité spinner (aria-hidden, sr-only) |
| `packages/dashboard/package.json` | Remplacement clsx/tailwind-merge par `@unanima/core` |
| `packages/dashboard/src/cn.ts` | Supprimé (doublon) |
| `packages/dashboard/src/ChartWrapper.tsx` | État vide, error boundary, résolution CSS vars |
| `packages/dashboard/src/*.tsx` (x7) | Import cn depuis `@unanima/core` |

## Validation

- [x] Lint : OK (0 erreurs)
- [x] Type-check / Build : OK (3 packages)
- [x] Tests : 18/18 réussis

Fixes #23, Fixes #24, Fixes #25, Fixes #26

https://claude.ai/code/session_016E2DNhXPVc4D4fQ445jUnr