### PR TITLE
feat(sprintix): add sprint execution skill and integrate across skill ecosystem

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -80,6 +80,7 @@ d'une aide précieuse.
 | Écriture de tests, mock, fixture, factory, vitest, playwright | **testix** | Étape 3 (écriture des tests) et étape 4 (validation) |
 | Intégration tierce, webhook, Salesforce, SAP, Resend, circuit breaker | **integratix** | Étape 2 (architecture intégration) et étape 3 (implémentation) |
 | Modification de package partagé, impact cross-app, socle commun | **soclix** | Étape 1 (analyse d'impact) et étape 3 (validation cross-app) |
+| Issue faisant partie d'un sprint planifié (.sprint/sprint-N.md) | **sprintix** | Contexte sprint fourni automatiquement si exécuté depuis sprintix |
 | Code implémenté à revoir pour qualité et réutilisation | **simplify** | Étape 3 (après implémentation, avant commit) |
 
 ### Règles d'invocation
@@ -331,6 +332,25 @@ approche proposée. Enchaîne 1 → 6 sans interaction.
 
 ## ÉTAPE 3 — IMPLÉMENTATION
 
+### Mise à jour du statut GitHub Project
+
+Au début de l'implémentation, mettre à jour le statut de l'issue dans le
+GitHub Project pour refléter la progression :
+
+```bash
+# Identifier le projet et l'item (Unanima Platform = projet 4)
+OWNER=dduquenne
+PROJECT_NUM=4
+ISSUE_NUM=<numéro de l'issue>
+
+# Le statut passe de 📋 Backlog à 🏗️ En cours
+# Utiliser gh project item-edit (voir sprintix/references/github-project-api.md)
+```
+
+Si l'issue fait partie d'un sprint (fichier `.sprint/sprint-N.md` existant),
+vérifier le plan pour connaître la phase et l'ordre d'exécution, et signaler
+le contexte sprint dans les messages de commit.
+
 ### Git workflow
 ```bash
 git checkout main && git pull origin main
@@ -456,15 +476,28 @@ Attendre checks verts, puis merge squash via `gh pr merge --squash`.
 
 ## ÉTAPE 5 — POST-MERGE & PRODUCTION
 
-### 5.1 — CI sur main
+### 5.1 — Mise à jour du statut GitHub Project
+Après le merge, mettre à jour le statut de l'issue dans le GitHub Project :
+- Statut → ✅ Terminé
+
+Si l'issue fait partie d'un sprint (`.sprint/sprint-N.md`), mettre à jour
+le plan en cochant l'issue :
+```markdown
+# Avant
+| 3 | #51 | Index manquants | 🟠 Haute | databasix | — | — |
+# Après
+| ✅ 3 | #51 | Index manquants | 🟠 Haute | databasix | — | Fait (YYYY-MM-DD) |
+```
+
+### 5.2 — CI sur main
 Vérifier les checks du commit de merge via GitHub API.
 Si échec : diagnostiquer, corriger sur branche `fix/<scope>-hotfix`, nouvelle PR.
 
-### 5.2 — Déploiement Vercel
+### 5.3 — Déploiement Vercel
 Via MCP Vercel : vérifier build production réussi + runtime fonctionnel +
 logs Serverless sans erreur.
 
-### 5.3 — Rollback (si production cassée)
+### 5.4 — Rollback (si production cassée)
 Rollback immédiat via MCP Vercel (redéploiement du build précédent),
 puis corriger via workflow PR standard.
 
@@ -518,3 +551,5 @@ puis corriger via workflow PR standard.
 - [ ] CLAUDE.md mis à jour (si applicable)
 - [ ] Env vars documentées dans `.env.example` + Vercel (si applicable)
 - [ ] Migration SQL commitée (si applicable)
+- [ ] Statut GitHub Project mis à jour (📋 → 🏗️ → ✅)
+- [ ] Plan sprint `.sprint/sprint-N.md` mis à jour (si applicable)

--- a/.claude/skills/pilotix/SKILL.md
+++ b/.claude/skills/pilotix/SKILL.md
@@ -18,6 +18,7 @@ compatibility:
     - recettix      # Pour définir les critères de validation globaux du plan
     - soclix        # Pour évaluer l'impact sur le socle commun lors de la planification
     - documentalix  # Pour documenter les plans et décisions d'orchestration (ADR)
+    - sprintix      # Pour exécuter les plans de sprint séquentiellement (bras armé de pilotix)
 ---
 
 # Pilotix — Orchestrateur & Tech Lead Virtuel
@@ -220,6 +221,53 @@ Quand `/issue` est invoqué sur une issue créée par Pilotix :
 - Le champ "Skills à invoquer" guide directement l'étape 1 (investigation)
 - Les dépendances indiquent l'ordre de traitement
 - Les critères d'acceptation alimentent l'étape 4 (validation)
+
+---
+
+## Phase 6 — Génération du plan de sprint pour Sprintix
+
+Quand le plan d'exécution est validé et que les issues GitHub sont créées,
+Pilotix peut générer un fichier `.sprint/sprint-N.md` exploitable par **Sprintix**
+pour une exécution industrialisée.
+
+### Processus de génération
+
+1. **Lire le GitHub Project** pour collecter les issues de l'itération
+2. **Grouper en phases** selon les dépendances et la priorité :
+   - Phase 1 — Prérequis critiques (séquentiel) : issues bloquantes
+   - Phase 2 — Corrections indépendantes (parallélisable) : issues sans dépendance
+   - Phase 3 — Risque maîtrisé (review humain) : CVE, breaking changes
+3. **Écrire le fichier** `.sprint/sprint-N.md` selon le format standard
+4. **Proposer** le passage de relais à Sprintix : `/sprintix run N`
+
+### Format du plan (voir `.sprint/README.md`)
+
+Chaque phase contient un tableau :
+
+```markdown
+| Ordre | Issue | Titre | Priorité | Skills | Dépend de | Review |
+|-------|-------|-------|----------|--------|-----------|--------|
+| 1 | #44 | Description | 🔴 Critique | securix, soclix | — | — |
+```
+
+Et un point de contrôle :
+
+```markdown
+**Point de contrôle Phase N :**
+- [ ] `pnpm build` passe
+- [ ] `pnpm test` passe
+```
+
+### Articulation Pilotix → Sprintix
+
+```
+Pilotix = cerveau stratégique (planifie, ordonne, arbitre)
+Sprintix = bras armé (exécute, valide, met à jour les statuts)
+```
+
+Pilotix produit le plan, Sprintix l'exécute. Pilotix peut être réinvoqué
+pendant un sprint si Sprintix rencontre un blocage nécessitant un
+réordonnancement.
 
 ---
 

--- a/.claude/skills/repositorix/SKILL.md
+++ b/.claude/skills/repositorix/SKILL.md
@@ -15,6 +15,7 @@ compatibility:
     - deploix      # Pour la coordination CI/CD → déploiement Vercel (workflows, env vars, rollback)
     - pilotix      # Pour la création d'issues structurées et le séquencement des PRs
     - soclix       # Quand une PR touche le socle commun et nécessite une CI cross-app
+    - sprintix     # Pour synchroniser les statuts du GitHub Project avec la progression sprint
 ---
 
 # Repositorix — Gestion de projet GitHub
@@ -530,16 +531,49 @@ Créer un milestone par version planifiée avec :
 ## 10. Workflow type pour une tâche
 
 ```
-1. Créer/sélectionner une issue → l'assigner → changer statut "In Progress"
-2. git checkout develop && git pull
-3. git checkout -b feature/42-ma-feature
-4. [développer, committer régulièrement en Conventional Commits]
-5. git push -u origin feature/42-ma-feature
-6. Ouvrir une PR vers develop → lier l'issue → demander review
-7. CI passe ✓ → reviewer approuve ✓ → Squash & Merge
-8. Issue fermée automatiquement (via "Closes #42" dans la PR)
-9. Branche supprimée automatiquement
-10. Pour une release : suivre §7 (release branch → tag → GitHub Release)
+1.  Créer/sélectionner une issue → l'assigner → changer statut "In Progress"
+2.  Mettre à jour le statut dans le GitHub Project → 🏗️ En cours
+3.  git checkout develop && git pull
+4.  git checkout -b feature/42-ma-feature
+5.  [développer, committer régulièrement en Conventional Commits]
+6.  git push -u origin feature/42-ma-feature
+7.  Ouvrir une PR vers develop → lier l'issue → demander review
+8.  Mettre à jour le statut dans le GitHub Project → 👀 En review
+9.  CI passe ✓ → reviewer approuve ✓ → Squash & Merge
+10. Issue fermée automatiquement (via "Closes #42" dans la PR)
+11. Mettre à jour le statut dans le GitHub Project → ✅ Terminé
+12. Branche supprimée automatiquement
+13. Pour une release : suivre §7 (release branch → tag → GitHub Release)
+```
+
+### Mise à jour des statuts GitHub Project
+
+Chaque transition d'état d'une issue doit être reflétée dans le GitHub Project.
+C'est essentiel pour le suivi de progression par **sprintix** et pour la
+visibilité du board.
+
+| Moment | Statut Project | Qui déclenche |
+|--------|---------------|---------------|
+| Début d'implémentation | 📋 → 🏗️ En cours | `/issue` ou `/sprintix run` |
+| PR créée | 🏗️ → 👀 En review | `/issue` étape 4 |
+| PR mergée | 👀 → ✅ Terminé | `/issue` étape 5 ou automatique |
+| Issue reportée | 📋 → ⏭️ Reporté | `/sprintix` si blocage |
+
+Commandes `gh` pour la mise à jour (voir `sprintix/references/github-project-api.md`
+pour les détails) :
+
+```bash
+# Récupérer le projet et l'item
+PROJECT_NUM=4  # Unanima Platform
+OWNER=dduquenne
+
+# Lister les items pour trouver l'ID
+gh project item-list $PROJECT_NUM --owner $OWNER --format json | \
+  jq '.items[] | select(.content.number == 42) | .id'
+
+# Modifier le statut via gh project item-edit
+gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> \
+  --field-id <STATUS_FIELD_ID> --single-select-option-id <OPTION_ID>
 ```
 
 ---

--- a/.claude/skills/soclix/SKILL.md
+++ b/.claude/skills/soclix/SKILL.md
@@ -22,6 +22,7 @@ compatibility:
     - documentalix # Pour documenter les changements d'API publique du socle (ADR, CHANGELOG)
     - migratix     # Pour les migrations de schéma partagé (tables communes)
     - repositorix  # Pour la stratégie de PR et CI quand le socle change
+    - sprintix     # Pour mettre à jour la progression sprint quand le socle est modifié
 ---
 
 # Soclix — Gardien du Socle Commun
@@ -230,6 +231,22 @@ Vérifier après merge :
 - Les 3 builds Vercel se lancent
 - Les 3 builds réussissent
 - Les 3 apps sont fonctionnelles post-deploy
+
+---
+
+## Contexte sprint
+
+Quand une modification du socle s'inscrit dans un sprint (fichier
+`.sprint/sprint-N.md` existant), Soclix doit :
+
+1. **Vérifier le plan** : l'issue traitée est-elle dans le sprint courant ?
+2. **Signaler les impacts cross-app** à Sprintix pour qu'il puisse ajuster
+   les points de contrôle entre phases
+3. **Confirmer le build des 3 apps** avant de marquer l'issue comme terminée
+   dans le plan sprint
+
+C'est particulièrement important pour les sprints d'audit (comme le Sprint 1
+Fondations) où de nombreuses issues touchent le socle et pourraient interagir.
 
 ---
 


### PR DESCRIPTION
## Summary

- **New skill `sprintix`** with 4 modes (PLAN, RUN, STATUS, NEXT) for industrialized sprint execution
- **New `.sprint/` infrastructure** with Sprint 1 plan pre-populated from GitHub Project backlog (7 issues, 3 phases)
- **Updated `pilotix`** with Phase 6 for `.sprint/` plan generation and sprintix handoff
- **Updated `repositorix`** with GitHub Project status update workflow at each transition
- **Updated `/issue` command** with sprint-aware status updates at étape 3 and étape 5, plus checklist items
- **Updated `soclix`** with sprint context awareness for cross-app impact during sprint execution

## Test plan

- [ ] Verify `/sprintix status 1` reads `.sprint/sprint-1.md` correctly
- [ ] Verify `/sprintix run 1` sequences issues in the correct order
- [ ] Verify `/issue #N` updates GitHub Project status at implementation start and post-merge
- [ ] Verify `pilotix` recommends sprintix and generates sprint plans

https://claude.ai/code/session_01WiFUA91btg8aoCjvDAnEyW