### PR TITLE
docs(links): SPC-0003 + maquettes SVG haute-fidélité (MAQ-01 à MAQ-09)

### DIFF
--- a/docs/links/INDEX.md
+++ b/docs/links/INDEX.md
@@ -13,7 +13,7 @@
 
 | Réf. | Écran | Rôle | Format | Version | Mise à jour |
 |---|---|---|---|---|---|
-| MAQ-01 | Page de connexion | Tous | SVG | 1.0 | 2026-03-23 |
+| MAQ-01 | Page de connexion | Tous | SVG | 1.1 | 2026-03-23 |
 | MAQ-02 | Dashboard bénéficiaire | Bénéficiaire | SVG | 1.0 | 2026-03-23 |
 | MAQ-03 | Saisie de phase | Bénéficiaire | SVG | 1.0 | 2026-03-23 |
 | MAQ-04 | Dashboard consultant | Consultant | SVG | 1.0 | 2026-03-23 |

--- a/docs/links/mockups/MAQ-01-login.svg
+++ b/docs/links/mockups/MAQ-01-login.svg
@@ -1,35 +1,36 @@
-<!-- MAQ-01 | Login | Link's Accompagnement | v1.0 | 2026-03-23 -->
+<!-- MAQ-01 | Login | Link's Accompagnement | v1.1 | 2026-03-23 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" width="1200" height="800" font-family="'Inter', 'Segoe UI', Arial, sans-serif">
 
-  <!-- ======================== FOND ======================== -->
-  <rect width="1200" height="800" fill="#F5F7FA"/>
-
-  <!-- Dégradé subtil en haut de page -->
+  <!-- ======================== DEFS (unique bloc) ======================== -->
   <defs>
+    <!-- Dégradé fond haut de page -->
     <linearGradient id="topGradient" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#1E6FC0" stop-opacity="0.07"/>
       <stop offset="100%" stop-color="#F5F7FA" stop-opacity="0"/>
     </linearGradient>
+    <!-- Dégradé bouton -->
+    <linearGradient id="btnGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2E7FD0"/>
+      <stop offset="100%" stop-color="#1A5FA8"/>
+    </linearGradient>
+    <!-- Ombre carte -->
     <filter id="cardShadow" x="-10%" y="-10%" width="120%" height="130%">
       <feDropShadow dx="0" dy="4" stdDeviation="16" flood-color="#0D3B6E" flood-opacity="0.10"/>
     </filter>
-    <filter id="inputFocus" x="-2%" y="-10%" width="104%" height="130%">
-      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#1E6FC0" flood-opacity="0.15"/>
-    </filter>
   </defs>
 
+  <!-- ======================== FOND ======================== -->
+  <rect width="1200" height="800" fill="#F5F7FA"/>
   <rect width="1200" height="280" fill="url(#topGradient)"/>
 
   <!-- ======================== LOGO + HEADLINE ======================== -->
-  <!-- Icône logo (cercle + lettre stylisée) -->
   <g transform="translate(600, 112)">
     <!-- Cercle de fond du logo -->
     <circle cx="0" cy="-32" r="36" fill="#1E6FC0"/>
     <!-- Lettre L stylisée -->
     <text x="0" y="-18" text-anchor="middle" font-size="32" font-weight="700" fill="#FFFFFF" letter-spacing="-1">L</text>
-    <!-- Apostrophe stylisée -->
+    <!-- Point accent -->
     <circle cx="12" cy="-46" r="4" fill="#FF6B35"/>
-
     <!-- Nom de l'application -->
     <text x="0" y="26" text-anchor="middle" font-size="26" font-weight="700" fill="#0D3B6E" letter-spacing="-0.5">
       Link's Accompagnement
@@ -42,14 +43,11 @@
 
   <!-- ======================== CARTE LOGIN ======================== -->
   <!-- Ombre de la carte -->
-  <rect x="400" y="188" width="400" height="488" rx="16" ry="16" fill="#0D3B6E" opacity="0.08" transform="translate(0, 6)"/>
-
+  <rect x="400" y="194" width="400" height="488" rx="16" ry="16" fill="#0D3B6E" opacity="0.08"/>
   <!-- Corps de la carte -->
   <rect x="400" y="188" width="400" height="488" rx="16" ry="16" fill="#FFFFFF" filter="url(#cardShadow)"/>
-
   <!-- Barre de couleur en haut de la carte -->
   <rect x="400" y="188" width="400" height="5" rx="2" fill="#1E6FC0"/>
-  <rect x="400" y="191" width="400" height="2" rx="0" fill="#1E6FC0" opacity="0.3"/>
 
   <!-- ---- Titre "Connexion" ---- -->
   <text x="600" y="250" text-anchor="middle" font-size="22" font-weight="700" fill="#0D3B6E" letter-spacing="-0.3">
@@ -60,7 +58,6 @@
 
   <!-- ---- Label + Champ Email ---- -->
   <text x="432" y="300" font-size="13" font-weight="600" fill="#4A4A4A">Adresse email</text>
-
   <!-- Input email (état normal) -->
   <rect x="432" y="308" width="336" height="44" rx="8" ry="8" fill="#FFFFFF" stroke="#DCE1EB" stroke-width="1.5"/>
   <!-- Icône email (enveloppe simplifiée) -->
@@ -71,8 +68,7 @@
 
   <!-- ---- Label + Champ Mot de passe ---- -->
   <text x="432" y="378" font-size="13" font-weight="600" fill="#4A4A4A">Mot de passe</text>
-
-  <!-- Input password (état avec valeur masquée) -->
+  <!-- Input password (état focus) -->
   <rect x="432" y="386" width="336" height="44" rx="8" ry="8" fill="#FFFFFF" stroke="#1E6FC0" stroke-width="2"/>
   <!-- Halo focus bleu subtil -->
   <rect x="430" y="384" width="340" height="48" rx="10" ry="10" fill="none" stroke="#1E6FC0" stroke-width="0.5" opacity="0.3"/>
@@ -96,54 +92,41 @@
     <line x1="-10" y1="-8" x2="10" y2="8" stroke="#9BA8BF" stroke-width="1.5" stroke-linecap="round"/>
   </g>
 
-  <!-- ---- Lien "Mot de passe oublié ?" ---- -->
-  <text x="768" y="455" text-anchor="end" font-size="12.5" fill="#1E6FC0" text-decoration="underline" style="cursor:pointer">
+  <!-- ---- Lien "Mot de passe oublié ?" (souligné via <line>) ---- -->
+  <text x="768" y="455" text-anchor="end" font-size="12.5" fill="#1E6FC0">
     Mot de passe oublié ?
   </text>
+  <line x1="636" y1="457" x2="768" y2="457" stroke="#1E6FC0" stroke-width="1"/>
 
   <!-- ---- Message d'erreur ---- -->
-  <!-- Fond du message d'erreur -->
   <rect x="432" y="466" width="336" height="40" rx="8" ry="8" fill="#FFF2F2" stroke="#E53935" stroke-width="1.2"/>
-  <!-- Icône alerte -->
   <circle cx="452" cy="486" r="8" fill="#E53935"/>
   <text x="452" y="490" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">!</text>
-  <!-- Texte d'erreur -->
   <text x="468" y="490" font-size="12.5" fill="#C62828" font-weight="500">
     Email ou mot de passe incorrect.
   </text>
 
   <!-- ---- Bouton "Se connecter" ---- -->
   <!-- Ombre du bouton -->
-  <rect x="432" y="523" width="336" height="46" rx="10" ry="10" fill="#0D3B6E" opacity="0.18" transform="translate(0, 3)"/>
-  <!-- Bouton principal -->
-  <rect x="432" y="523" width="336" height="46" rx="10" ry="10" fill="#1E6FC0"/>
-  <!-- Dégradé sur le bouton -->
-  <defs>
-    <linearGradient id="btnGradient" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2E7FD0"/>
-      <stop offset="100%" stop-color="#1A5FA8"/>
-    </linearGradient>
-  </defs>
+  <rect x="432" y="526" width="336" height="46" rx="10" ry="10" fill="#0D3B6E" opacity="0.18"/>
+  <!-- Bouton avec dégradé -->
   <rect x="432" y="523" width="336" height="46" rx="10" ry="10" fill="url(#btnGradient)"/>
   <!-- Texte bouton -->
   <text x="600" y="551" text-anchor="middle" font-size="15" font-weight="700" fill="#FFFFFF" letter-spacing="0.3">
     Se connecter
   </text>
   <!-- Flèche sur le bouton -->
-  <g transform="translate(742, 546)">
-    <polyline points="-5,-5 0,0 -5,5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"/>
-  </g>
+  <polyline points="737,541 742,546 737,551" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"/>
 
   <!-- ---- Séparateur + Aide ---- -->
   <line x1="432" y1="592" x2="576" y2="592" stroke="#DCE1EB" stroke-width="1"/>
   <text x="600" y="596" text-anchor="middle" font-size="11.5" fill="#9BA8BF">ou</text>
   <line x1="624" y1="592" x2="768" y2="592" stroke="#DCE1EB" stroke-width="1"/>
 
-  <!-- Lien contact support -->
-  <text x="600" y="628" text-anchor="middle" font-size="12.5" fill="#6B7A99">
-    Besoin d'aide ?
-    <tspan fill="#1E6FC0" text-decoration="underline"> Contacter le support</tspan>
-  </text>
+  <!-- Lien contact support (texte souligné via <line>) -->
+  <text x="600" y="628" text-anchor="middle" font-size="12.5" fill="#6B7A99">Besoin d'aide ?</text>
+  <text x="600" y="648" text-anchor="middle" font-size="12.5" fill="#1E6FC0">Contacter le support</text>
+  <line x1="524" y1="650" x2="676" y2="650" stroke="#1E6FC0" stroke-width="1"/>
 
   <!-- ======================== FOOTER ======================== -->
   <text x="600" y="760" text-anchor="middle" font-size="11" fill="#9BA8BF">
@@ -156,16 +139,13 @@
   <!-- ======================== ANNOTATIONS MAQUETTE ======================== -->
   <!-- Badge version -->
   <rect x="30" y="20" width="110" height="26" rx="6" fill="#1E6FC0" opacity="0.12"/>
-  <text x="85" y="37" text-anchor="middle" font-size="11" font-weight="600" fill="#1E6FC0">MAQ-01 · v1.0</text>
-
+  <text x="85" y="37" text-anchor="middle" font-size="11" font-weight="600" fill="#1E6FC0">MAQ-01 · v1.1</text>
   <!-- Badge statut -->
   <rect x="152" y="20" width="90" height="26" rx="6" fill="#28A745" opacity="0.12"/>
   <text x="197" y="37" text-anchor="middle" font-size="11" font-weight="600" fill="#28A745">Haute-fidélité</text>
-
   <!-- Date -->
   <text x="1170" y="35" text-anchor="end" font-size="11" fill="#9BA8BF">2026-03-23</text>
-
-  <!-- Annotation couleur palette (coins) -->
+  <!-- Palette -->
   <g transform="translate(30, 720)">
     <text x="0" y="0" font-size="10" fill="#9BA8BF" font-weight="600">Palette :</text>
     <rect x="60" y="-10" width="14" height="14" rx="3" fill="#1E6FC0"/>


### PR DESCRIPTION
## Résumé

Ajout de l'ensemble de la documentation fonctionnelle et des maquettes haute-fidélité pour le projet Link's Accompagnement.

## Documents ajoutés

- **SPC-0003** — Spécifications fonctionnelles détaillées (1 604 lignes)
  - 25 User Stories couvrant 4 modules : AUTH, BEN, CON, ADM
  - Critères d'acceptation Gherkin, règles métier, messages d'erreur
  - ⚠️ US-CON-08 : décision client requise sur les notifications email (H1 vs H2)

- **MAQ-01 à MAQ-09** — 9 maquettes SVG haute-fidélité (1200×800 px)
  - MAQ-01 : Page de connexion (v1.1 — SVG corrigé)
  - MAQ-02 : Dashboard bénéficiaire
  - MAQ-03 : Saisie de phase
  - MAQ-04 : Dashboard consultant
  - MAQ-05 : Fiche bénéficiaire (vue consultant)
  - MAQ-06 : Comptes-rendus de séances
  - MAQ-07 : Dashboard super admin
  - MAQ-08 : Gestion des utilisateurs
  - MAQ-09 : Planification des rendez-vous

- **INDEX.md** — mis à jour avec tous les documents, structure des dossiers et cross-références

## Corrections SVG (MAQ-01 v1.1)

- Fusion des deux blocs `<defs>` en un seul bloc en tête de fichier
- Suppression de `style="cursor:pointer"` (non supporté en SVG statique)
- Remplacement des `<tspan text-decoration>` par des `<line>` pour les soulignements

## Palette appliquée

Tous les SVG respectent les tokens Link's : `#1E6FC0`, `#0D3B6E`, `#FF6B35`, `#28A745`, `#F5F7FA`, `#4A4A4A`, `#DCE1EB`.

https://claude.ai/code/session_01Xzvu1GViP5QzxiRdzE4kwX