### PR TITLE
feat(tooling): configure Supabase MCP servers scoped per project

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,34 @@
+{
+  "mcpServers": {
+    "supabase-links": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref",
+        "wnulfyioossihuksctjb"
+      ]
+    },
+    "supabase-omega": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref",
+        "grlepmbgfgafkhxhgurv"
+      ]
+    },
+    "supabase-creai": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref",
+        "CREAI_PROJECT_REF_A_DEFINIR"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,6 +446,44 @@ pnpm dev:omega
 
 ---
 
+## Configuration MCP (Model Context Protocol)
+
+Le projet utilise le [MCP Supabase](https://github.com/supabase-community/supabase-mcp) pour permettre à Claude Code d'accéder directement aux bases de données des 3 projets clients.
+
+### Fichier `.mcp.json` (racine du monorepo)
+
+Le fichier `.mcp.json` à la racine définit 3 serveurs MCP, chacun scopé sur un seul projet Supabase via `--project-ref`. Claude Code charge ce fichier automatiquement.
+
+| Serveur MCP | App | project_ref |
+|---|---|---|
+| `supabase-links` | Link's Accompagnement | `wnulfyioossihuksctjb` |
+| `supabase-omega` | Omega Automotive | `grlepmbgfgafkhxhgurv` |
+| `supabase-creai` | CREAI Île-de-France | À définir |
+
+### Prérequis — Personal Access Token (PAT)
+
+Le MCP Supabase requiert un PAT Supabase dans la variable d'environnement `SUPABASE_ACCESS_TOKEN`.
+
+**Configuration locale** (à faire une fois par poste) :
+
+1. Générer un PAT sur [https://supabase.com/dashboard/account/tokens](https://supabase.com/dashboard/account/tokens)
+2. Ajouter dans `~/.claude/settings.json` :
+   ```json
+   {
+     "env": {
+       "SUPABASE_ACCESS_TOKEN": "votre-pat-ici"
+     }
+   }
+   ```
+
+> **Important** : Ne jamais committer le PAT dans le dépôt. Le fichier `~/.claude/settings.json` est personnel et non versionné.
+
+### Activation des serveurs MCP
+
+Au premier démarrage après clonage, Claude Code propose d'activer les serveurs MCP du `.mcp.json`. Approuver les 3 serveurs. Ils peuvent ensuite être gérés via `/mcp` dans Claude Code.
+
+---
+
 ## Règles strictes
 
 1. **Ne jamais importer de code d'une app vers une autre** — les apps sont isolées


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Ajoute `.mcp.json` à la racine du monorepo avec 3 serveurs MCP Supabase, chacun scopé via `--project-ref` (Links, Omega, CREAI)
- Documente la configuration dans `CLAUDE.md` : prérequis PAT, étapes d'activation, tableau des `project_ref`

## Détail des serveurs MCP

| Serveur | App | project_ref |
|---|---|---|
| `supabase-links` | Link's Accompagnement | `wnulfyioossihuksctjb` |
| `supabase-omega` | Omega Automotive | `grlepmbgfgafkhxhgurv` |
| `supabase-creai` | CREAI Île-de-France | À définir |

## Test plan

- [ ] Cloner le repo sur un poste neuf, vérifier que Claude Code propose bien d'activer les 3 serveurs MCP au démarrage
- [ ] Configurer `SUPABASE_ACCESS_TOKEN` dans `~/.claude/settings.json` et vérifier la connexion via `/mcp`
- [ ] Mettre à jour `supabase-creai` avec le `project_ref` CREAI une fois disponible

https://claude.ai/code/session_014yWqQWyxR7ZQL7MLpTg9JZ
EOF
)