### PR TITLE
Add SUPABASE_ACCESS_TOKEN env vars to MCP server configs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,1 @@
-{
-  "mcpServers": {
-    "supabase": {
-      "command": "npx",
-      "args": ["-y", "@supabase/mcp-server-supabase@latest"],
-      "env": {
-        "SUPABASE_ACCESS_TOKEN": "sbp_4ac507823dc244769b3cd90be8afaf16bc5e5da9"
-      }
-    }
-  }
-}
+{}

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,10 @@
         "@supabase/mcp-server-supabase@latest",
         "--project-ref",
         "wnulfyioossihuksctjb"
-      ]
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
     },
     "supabase-omega": {
       "type": "stdio",
@@ -18,7 +21,10 @@
         "@supabase/mcp-server-supabase@latest",
         "--project-ref",
         "grlepmbgfgafkhxhgurv"
-      ]
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
     },
     "supabase-creai": {
       "type": "stdio",
@@ -28,7 +34,10 @@
         "@supabase/mcp-server-supabase@latest",
         "--project-ref",
         "CREAI_PROJECT_REF_A_DEFINIR"
-      ]
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR updates the MCP server configuration to properly pass the Supabase access token to all server instances via environment variables, and removes hardcoded credentials from the Claude settings file.

## Key Changes
- Added `env` configuration with `SUPABASE_ACCESS_TOKEN` environment variable to all three Supabase MCP server definitions in `.mcp.json`:
  - `supabase-alpha`
  - `supabase-omega`
  - `supabase-creai`
- Cleared `.claude/settings.json` to remove hardcoded Supabase access token that was previously stored in plaintext

## Implementation Details
- The `SUPABASE_ACCESS_TOKEN` is now passed as an environment variable using the `${SUPABASE_ACCESS_TOKEN}` placeholder, which will be resolved from the system environment at runtime
- This approach improves security by removing hardcoded credentials from configuration files and allowing the token to be managed through environment variables instead
- All three Supabase server instances now have consistent configuration structure with the new `env` block

https://claude.ai/code/session_01VmURyffGzVGeswF61M5Eru