### PR TITLE
fix(health): add database connectivity check to health endpoints

### DIFF
--- a/apps/creai/src/app/api/health/route.ts
+++ b/apps/creai/src/app/api/health/route.ts
@@ -1,9 +1,81 @@
 import { NextResponse } from 'next/server'
+import { createAdminClient } from '@unanima/db'
 
-export function GET() {
-  return NextResponse.json({
-    status: 'ok',
-    app: 'creai',
-    timestamp: new Date().toISOString(),
-  })
+export async function GET() {
+  const timestamp = new Date().toISOString()
+
+  // Check environment variables
+  const envCheck = {
+    NEXT_PUBLIC_SUPABASE_URL: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+  }
+
+  const missingVars = Object.entries(envCheck)
+    .filter(([, ok]) => !ok)
+    .map(([name]) => name)
+
+  if (missingVars.length > 0) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        app: 'creai',
+        timestamp,
+        database: {
+          connected: false,
+          error: `Missing environment variables: ${missingVars.join(', ')}`,
+        },
+      },
+      { status: 503 },
+    )
+  }
+
+  // Test database connectivity
+  const start = performance.now()
+  try {
+    const supabase = createAdminClient()
+    const { error } = await supabase.from('profiles').select('id').limit(1)
+    const latencyMs = Math.round(performance.now() - start)
+
+    if (error) {
+      return NextResponse.json(
+        {
+          status: 'degraded',
+          app: 'creai',
+          timestamp,
+          database: {
+            connected: false,
+            latencyMs,
+            error: error.message,
+          },
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json({
+      status: 'ok',
+      app: 'creai',
+      timestamp,
+      database: {
+        connected: true,
+        latencyMs,
+      },
+    })
+  } catch (err) {
+    const latencyMs = Math.round(performance.now() - start)
+    return NextResponse.json(
+      {
+        status: 'error',
+        app: 'creai',
+        timestamp,
+        database: {
+          connected: false,
+          latencyMs,
+          error: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 503 },
+    )
+  }
 }

--- a/apps/links/src/app/api/health/route.ts
+++ b/apps/links/src/app/api/health/route.ts
@@ -1,9 +1,81 @@
 import { NextResponse } from 'next/server'
+import { createAdminClient } from '@unanima/db'
 
-export function GET() {
-  return NextResponse.json({
-    status: 'ok',
-    app: 'links',
-    timestamp: new Date().toISOString(),
-  })
+export async function GET() {
+  const timestamp = new Date().toISOString()
+
+  // Check environment variables
+  const envCheck = {
+    NEXT_PUBLIC_SUPABASE_URL: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+  }
+
+  const missingVars = Object.entries(envCheck)
+    .filter(([, ok]) => !ok)
+    .map(([name]) => name)
+
+  if (missingVars.length > 0) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        app: 'links',
+        timestamp,
+        database: {
+          connected: false,
+          error: `Missing environment variables: ${missingVars.join(', ')}`,
+        },
+      },
+      { status: 503 },
+    )
+  }
+
+  // Test database connectivity
+  const start = performance.now()
+  try {
+    const supabase = createAdminClient()
+    const { error } = await supabase.from('profiles').select('id').limit(1)
+    const latencyMs = Math.round(performance.now() - start)
+
+    if (error) {
+      return NextResponse.json(
+        {
+          status: 'degraded',
+          app: 'links',
+          timestamp,
+          database: {
+            connected: false,
+            latencyMs,
+            error: error.message,
+          },
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json({
+      status: 'ok',
+      app: 'links',
+      timestamp,
+      database: {
+        connected: true,
+        latencyMs,
+      },
+    })
+  } catch (err) {
+    const latencyMs = Math.round(performance.now() - start)
+    return NextResponse.json(
+      {
+        status: 'error',
+        app: 'links',
+        timestamp,
+        database: {
+          connected: false,
+          latencyMs,
+          error: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 503 },
+    )
+  }
 }

--- a/apps/omega/src/app/api/health/route.ts
+++ b/apps/omega/src/app/api/health/route.ts
@@ -1,9 +1,81 @@
 import { NextResponse } from 'next/server'
+import { createAdminClient } from '@unanima/db'
 
-export function GET() {
-  return NextResponse.json({
-    status: 'ok',
-    app: 'omega',
-    timestamp: new Date().toISOString(),
-  })
+export async function GET() {
+  const timestamp = new Date().toISOString()
+
+  // Check environment variables
+  const envCheck = {
+    NEXT_PUBLIC_SUPABASE_URL: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+  }
+
+  const missingVars = Object.entries(envCheck)
+    .filter(([, ok]) => !ok)
+    .map(([name]) => name)
+
+  if (missingVars.length > 0) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        app: 'omega',
+        timestamp,
+        database: {
+          connected: false,
+          error: `Missing environment variables: ${missingVars.join(', ')}`,
+        },
+      },
+      { status: 503 },
+    )
+  }
+
+  // Test database connectivity
+  const start = performance.now()
+  try {
+    const supabase = createAdminClient()
+    const { error } = await supabase.from('profiles').select('id').limit(1)
+    const latencyMs = Math.round(performance.now() - start)
+
+    if (error) {
+      return NextResponse.json(
+        {
+          status: 'degraded',
+          app: 'omega',
+          timestamp,
+          database: {
+            connected: false,
+            latencyMs,
+            error: error.message,
+          },
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json({
+      status: 'ok',
+      app: 'omega',
+      timestamp,
+      database: {
+        connected: true,
+        latencyMs,
+      },
+    })
+  } catch (err) {
+    const latencyMs = Math.round(performance.now() - start)
+    return NextResponse.json(
+      {
+        status: 'error',
+        app: 'omega',
+        timestamp,
+        database: {
+          connected: false,
+          latencyMs,
+          error: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 503 },
+    )
+  }
 }


### PR DESCRIPTION
## Summary

- **Enrichit les 3 endpoints `/api/health`** (links, creai, omega) avec un test de connexion à la base de données Supabase
- **Vérifie la présence des variables d'environnement** (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`)
- **Exécute une requête DB** (`SELECT id FROM profiles LIMIT 1`) et mesure la latence de connexion
- **Retourne un diagnostic structuré** avec statuts `ok` (200), `degraded` (503) ou `error` (503)

### Réponse type (connexion OK)
```json
{
  "status": "ok",
  "app": "links",
  "timestamp": "2026-03-24T...",
  "database": { "connected": true, "latencyMs": 42 }
}
```

### Réponse type (erreur)
```json
{
  "status": "error",
  "app": "links",
  "timestamp": "2026-03-24T...",
  "database": { "connected": false, "error": "Missing environment variables: SUPABASE_SERVICE_ROLE_KEY" }
}
```

## Test plan

- [ ] Vérifier que chaque app retourne `database.connected: true` en Preview Deployment Vercel
- [ ] Vérifier le comportement avec une variable d'environnement manquante (status 503)
- [ ] Vérifier que la latence DB est raisonnable (< 500ms)

https://claude.ai/code/session_01XctKcwAakL1iGsFbykEbY5