### PR TITLE
fix(lint): remove unused variables in rgpd and dashboard test files

### DIFF
--- a/packages/dashboard/src/__tests__/components.test.ts
+++ b/packages/dashboard/src/__tests__/components.test.ts
@@ -3,11 +3,11 @@ import {
   KPICard, type KPICardProps,
   StatusBadge, type StatusBadgeProps, type StatusConfig,
   ProgressBar, type ProgressBarProps,
-  DataTable, type DataTableProps,
-  AlertPanel, type AlertPanelProps,
-  SearchBar, type SearchBarProps,
-  Layout, type LayoutProps,
-  ChartWrapper, type ChartWrapperProps,
+  DataTable,
+  AlertPanel,
+  SearchBar,
+  Layout,
+  ChartWrapper,
 } from '../index'
 
 describe('Dashboard component exports', () => {

--- a/packages/rgpd/src/__tests__/export-data.test.ts
+++ b/packages/rgpd/src/__tests__/export-data.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockSelect = vi.fn()
-const mockEq = vi.fn()
-const mockSingle = vi.fn()
-const mockOrder = vi.fn()
 const mockFrom = vi.fn()
 
 vi.mock('@supabase/supabase-js', () => ({


### PR DESCRIPTION
Fixes 4 lint errors in packages/rgpd/src/__tests__/export-data.test.ts
(unused mock variables) and 5 lint errors in
packages/dashboard/src/__tests__/components.test.ts (unused type imports),
which were causing CI lint checks to fail and blocking Vercel deployments.