### PR TITLE
fix(deploy): replace vercel-ignore.sh with turbo-ignore

### DIFF
--- a/.claude/skills/deploix/SKILL.md
+++ b/.claude/skills/deploix/SKILL.md
@@ -54,13 +54,15 @@ ne doit **jamais** impacter les autres.
 // apps/<app>/vercel.json
 {
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=@unanima/<app>",
-  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh <app>",
+  "ignoreCommand": "cd ../.. && npx turbo-ignore @unanima/<app>",
   "framework": "nextjs",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile"
 }
 ```
 
 **Ne jamais supprimer l'`ignoreCommand`** — il garantit l'isolation des déploiements.
+L'utilisation de `turbo-ignore` (au lieu d'un script bash custom) est essentielle :
+il exploite le graphe de dépendances Turborepo et fonctionne nativement avec les shallow clones de Vercel.
 
 ---
 

--- a/.claude/skills/soclix/SKILL.md
+++ b/.claude/skills/soclix/SKILL.md
@@ -225,7 +225,7 @@ Quand le socle change, le workflow `ci-packages.yml` teste les 3 apps en parall�
 ### 5.2 Impact sur les déploiements Vercel
 
 Une modification du socle déclenche potentiellement le redéploiement des 3 apps
-(via `scripts/vercel-ignore.sh` qui détecte les changements dans `packages/`).
+(via `npx turbo-ignore` qui utilise le graphe de dépendances Turborepo).
 
 Vérifier après merge :
 - Les 3 builds Vercel se lancent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,7 +410,7 @@ Chaque application est déployée **indépendamment** sur Vercel. Un échec de b
 
 ### Mécanismes en place
 
-1. **Vercel `ignoreCommand`** — Chaque `vercel.json` contient un `ignoreCommand` qui appelle `scripts/vercel-ignore.sh <app>`. Ce script vérifie si les fichiers pertinents à l'app ont changé ; sinon, le déploiement est ignoré.
+1. **Vercel `ignoreCommand`** — Chaque `vercel.json` utilise `npx turbo-ignore @unanima/<app>` qui exploite le graphe de dépendances Turborepo pour déterminer si un rebuild est nécessaire. Cette commande est nativement compatible avec les shallow clones de Vercel.
 
 2. **Turborepo `--filter`** — Chaque commande de build utilise `--filter=@unanima/<app>` pour ne construire que l'app ciblée et ses dépendances.
 

--- a/apps/creai/vercel.json
+++ b/apps/creai/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "installCommand": "pnpm install",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=@unanima/creai",
-  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh creai"
+  "ignoreCommand": "cd ../.. && npx turbo-ignore @unanima/creai"
 }

--- a/apps/links/vercel.json
+++ b/apps/links/vercel.json
@@ -1,7 +1,7 @@
 {
   "framework": "nextjs",
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=@unanima/links",
-  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh links"
+  "ignoreCommand": "cd ../.. && npx turbo-ignore @unanima/links"
 }
  

--- a/apps/omega/vercel.json
+++ b/apps/omega/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "installCommand": "pnpm install",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=@unanima/omega",
-  "ignoreCommand": "bash ../../scripts/vercel-ignore.sh omega"
+  "ignoreCommand": "cd ../.. && npx turbo-ignore @unanima/omega"
 }

--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -1,85 +1,21 @@
 #!/usr/bin/env bash
-# vercel-ignore.sh — Determines whether a Vercel deployment should proceed.
+# vercel-ignore.sh — DEPRECATED
 #
-# Vercel calls this script via the "ignoreCommand" in vercel.json.
-# Exit code 0 = skip deploy (no relevant changes)
-# Exit code 1 = proceed with deploy (changes detected)
+# This script has been replaced by `npx turbo-ignore` in each app's vercel.json.
+# Turborepo's built-in ignore command is more reliable because it:
+#   - Works correctly with Vercel's shallow clones
+#   - Uses the Turborepo dependency graph to detect transitive changes
+#   - Is maintained by the Vercel/Turborepo team
 #
-# IMPORTANT: Vercel runs ignoreCommand from the REPOSITORY ROOT,
-# not from the configured Root Directory.
+# This file is kept for reference only. It is no longer called by any vercel.json.
 #
-# Usage: ./scripts/vercel-ignore.sh <app-name>
+# Previous issues with this script:
+#   - git diff unreliable in Vercel's shallow clone environment
+#   - VERCEL_GIT_PREVIOUS_SHA fetch failures in depth=1 clones
+#   - Silent failures causing deployments to be incorrectly skipped
+#
+# See: https://turbo.build/repo/docs/guides/ci-vendors/vercel
 
-set -uo pipefail
-
-if [ $# -lt 1 ]; then
-  echo "Usage: $0 <app-name>"
-  exit 1
-fi
-
-APP_NAME="$1"
-APP_DIR="apps/${APP_NAME}"
-
-echo "Checking for changes relevant to app '${APP_NAME}'..."
-
-# Directories that, if changed, should trigger a rebuild of this app
-WATCHED_PATHS=(
-  "${APP_DIR}"
-  "packages/core"
-  "packages/auth"
-  "packages/dashboard"
-  "packages/db"
-  "packages/email"
-  "packages/rgpd"
-  "tooling"
-  "package.json"
-  "pnpm-lock.yaml"
-  "pnpm-workspace.yaml"
-  "tsconfig.base.json"
-)
-
-# Use Vercel's VERCEL_GIT_PREVIOUS_SHA if available, otherwise compare with HEAD~1
-PREVIOUS_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
-
-# If no previous SHA is available (first deployment), always deploy
-if [ -z "${PREVIOUS_SHA}" ]; then
-  echo "No previous deployment SHA found — proceeding with deployment of '${APP_NAME}'."
-  exit 1
-fi
-
-# Ensure the previous commit is available in shallow clones.
-# Strategy: progressively deepen the clone until PREVIOUS_SHA is reachable,
-# rather than fetching an arbitrary SHA directly (which may fail on GitHub
-# when the SHA is not a branch tip).
-echo "Fetching previous commit ${PREVIOUS_SHA}..."
-if ! git cat-file -e "${PREVIOUS_SHA}" 2>/dev/null; then
-  for depth in 10 50 100; do
-    git fetch --deepen="${depth}" origin 2>/dev/null || true
-    if git cat-file -e "${PREVIOUS_SHA}" 2>/dev/null; then
-      break
-    fi
-  done
-fi
-
-# Final fallback: try fetching the SHA directly (works if server allows it)
-if ! git cat-file -e "${PREVIOUS_SHA}" 2>/dev/null; then
-  git fetch --depth=1 origin "${PREVIOUS_SHA}" 2>/dev/null || true
-fi
-
-# Verify the commit is reachable
-if ! git cat-file -e "${PREVIOUS_SHA}" 2>/dev/null; then
-  echo "Previous SHA ${PREVIOUS_SHA} not reachable — proceeding with deployment of '${APP_NAME}'."
-  exit 1
-fi
-
-for path in "${WATCHED_PATHS[@]}"; do
-  if git diff --quiet "${PREVIOUS_SHA}" HEAD -- "${path}" 2>/dev/null; then
-    continue
-  else
-    echo "Changes detected in '${path}' — proceeding with deployment of '${APP_NAME}'."
-    exit 1
-  fi
-done
-
-echo "No relevant changes for app '${APP_NAME}' — skipping deployment."
-exit 0
+echo "DEPRECATED: This script is no longer used. See vercel.json for the new ignoreCommand."
+echo "Proceeding with deployment as a safety fallback."
+exit 1


### PR DESCRIPTION
## Summary

- **Replace** the custom `scripts/vercel-ignore.sh` with `npx turbo-ignore` in all 3 app `vercel.json` files
- **Root cause**: `git diff` in Vercel's shallow clones (depth=1) produced incorrect results, causing deployments to be falsely skipped despite real changes in `apps/links/`, `packages/auth/`, and `packages/db/`
- **Why turbo-ignore**: Turborepo's built-in solution natively handles Vercel's shallow clones and uses the dependency graph to detect transitive changes — no more manual path lists or SHA fetching
- **Harmonize** `installCommand` to `cd ../.. && pnpm install --frozen-lockfile` across all apps

## Files changed

| File | Change |
|---|---|
| `apps/links/vercel.json` | `ignoreCommand` → `npx turbo-ignore @unanima/links` |
| `apps/creai/vercel.json` | `ignoreCommand` → `npx turbo-ignore @unanima/creai` |
| `apps/omega/vercel.json` | `ignoreCommand` → `npx turbo-ignore @unanima/omega` |
| `scripts/vercel-ignore.sh` | Deprecated (safety fallback only) |
| `CLAUDE.md` | Updated isolation docs |
| `.claude/skills/deploix/SKILL.md` | Updated config example |
| `.claude/skills/soclix/SKILL.md` | Updated reference |

## Why previous fixes failed

The custom script (#139, #141, #144) tried to work around shallow clones by progressively deepening fetches, but `git diff` still produced unreliable results in Vercel's build environment. `turbo-ignore` eliminates this entire class of problems.

## Test plan

- [ ] Merge this PR and verify the next Vercel deployment for each app proceeds (not canceled)
- [ ] Verify that a commit touching only `apps/links/` does NOT trigger builds for creai/omega
- [ ] Verify that a commit touching `packages/auth/` triggers builds for all 3 apps

https://claude.ai/code/session_01W4AC7UkdnFY5DVX7EU8CT3