### PR TITLE
fix(auth): resolve login redirect loop caused by missing profile

### DIFF
--- a/apps/links/src/app/api/auth/ensure-profile/route.ts
+++ b/apps/links/src/app/api/auth/ensure-profile/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+import { createAdminClient } from '@unanima/db'
+import { cookies } from 'next/headers'
+
+export async function POST() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceRoleKey) {
+    return NextResponse.json(
+      { error: 'Configuration manquante' },
+      { status: 500 },
+    )
+  }
+
+  // Récupérer l'utilisateur authentifié via les cookies de session
+  const cookieStore = await cookies()
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll() {
+        // Route handler en lecture seule — pas besoin d'écrire les cookies
+      },
+    },
+  })
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+  }
+
+  // Vérifier si le profil existe déjà
+  const admin = createAdminClient()
+  const { data: existingProfile } = await admin
+    .from('profiles')
+    .select('id')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (existingProfile) {
+    return NextResponse.json({ status: 'exists' })
+  }
+
+  // Créer le profil manquant avec le client admin (bypass RLS)
+  const { error } = await admin.from('profiles').insert({
+    id: user.id,
+    email: user.email ?? '',
+    full_name:
+      (user.user_metadata?.full_name as string) ??
+      user.email?.split('@')[0] ??
+      '',
+    role: (user.user_metadata?.role as string) ?? 'beneficiaire',
+    is_active: true,
+    metadata: {},
+  })
+
+  if (error) {
+    // ON CONFLICT (id) DO NOTHING côté trigger — l'erreur
+    // de conflit de clé unique est acceptable (race condition)
+    if (error.code === '23505') {
+      return NextResponse.json({ status: 'exists' })
+    }
+    return NextResponse.json(
+      { error: 'Erreur lors de la création du profil' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ status: 'created' })
+}

--- a/apps/links/src/app/login/page.tsx
+++ b/apps/links/src/app/login/page.tsx
@@ -1,13 +1,25 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useMemo } from 'react'
 import { LoginForm, useAuth } from '@unanima/auth'
 import { Card } from '@unanima/core'
+
+const ERROR_MESSAGES: Record<string, string> = {
+  compte_desactive: 'Votre compte a été désactivé. Contactez votre administrateur.',
+  auth: 'Erreur d\u2019authentification. Veuillez réessayer.',
+  config: 'Erreur de configuration du serveur.',
+}
 
 export default function LoginPage() {
   const { user, isLoading } = useAuth()
   const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const urlError = useMemo(() => {
+    const errorCode = searchParams.get('error')
+    return errorCode ? ERROR_MESSAGES[errorCode] ?? null : null
+  }, [searchParams])
 
   useEffect(() => {
     if (!isLoading && user) {
@@ -38,6 +50,14 @@ export default function LoginPage() {
             Plateforme de suivi des bilans de comp&eacute;tences
           </p>
         </div>
+        {urlError && (
+          <div
+            className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+            role="alert"
+          >
+            {urlError}
+          </div>
+        )}
         <Card padding="lg">
           <LoginForm
             onResetPassword={() => router.push('/reset-password')}

--- a/apps/links/src/middleware.ts
+++ b/apps/links/src/middleware.ts
@@ -103,17 +103,24 @@ export default async function middleware(request: NextRequest) {
     .from('profiles')
     .select('role, is_active')
     .eq('id', user.id)
-    .single()
+    .maybeSingle()
 
-  // Compte inexistant ou désactivé (RG-AUTH-20)
-  if (!profile || !profile.is_active) {
+  // Compte explicitement désactivé (RG-AUTH-20)
+  // IMPORTANT : ne PAS déconnecter si le profil est absent — cela
+  // provoque une boucle de redirection infinie vers /login.
+  // Un profil manquant sera créé automatiquement via /api/auth/ensure-profile.
+  if (profile && !profile.is_active) {
     await supabase.auth.signOut()
     const loginUrl = new URL('/login', request.url)
     loginUrl.searchParams.set('error', 'compte_desactive')
     return NextResponse.redirect(loginUrl)
   }
 
-  const role: string = profile.role
+  // Rôle depuis le profil, ou fallback sur les métadonnées auth, ou défaut
+  const role: string =
+    profile?.role ??
+    (user.user_metadata?.role as string | undefined) ??
+    'beneficiaire'
 
   // ── Utilisateur connecté sur /login → rediriger (RG-AUTH-11) ─
   if (pathname === '/login' || pathname === '/') {

--- a/packages/auth/src/provider.tsx
+++ b/packages/auth/src/provider.tsx
@@ -46,7 +46,7 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
           .from('profiles')
           .select('*')
           .eq('id', authSession.user.id)
-          .single()
+          .maybeSingle()
 
         if (profile) {
           setUser({
@@ -56,6 +56,27 @@ export function AuthProvider({ config, children }: AuthProviderProps) {
             role: profile.role,
             isActive: profile.is_active,
             metadata: profile.metadata ?? {},
+          })
+        } else {
+          // Profil absent en BDD — fallback sur les métadonnées auth
+          // pour éviter que user reste null (boucle de redirection).
+          // Le profil sera créé automatiquement via /api/auth/ensure-profile.
+          const authUser = authSession.user
+          setUser({
+            id: authUser.id,
+            email: authUser.email ?? '',
+            fullName:
+              (authUser.user_metadata?.full_name as string) ??
+              authUser.email?.split('@')[0] ??
+              '',
+            role: (authUser.user_metadata?.role as string) ?? 'beneficiaire',
+            isActive: true,
+            metadata: {},
+          })
+
+          // Tenter la création automatique du profil en arrière-plan
+          fetch('/api/auth/ensure-profile', { method: 'POST' }).catch(() => {
+            // Silencieux — le profil sera recréé à la prochaine connexion
           })
         }
       } else {


### PR DESCRIPTION
## Summary\n\n- **Fix middleware redirect loop**: the middleware treated a missing profile (`!profile`) identically to a disabled account, signing the user out and redirecting to `/login` in an infinite loop\n- **Fix AuthProvider null user**: when the profile didn't exist in DB, `user` stayed `null` and the login page never redirected to dashboard\n- **Add auto-profile creation**: new `/api/auth/ensure-profile` API route creates missing profiles server-side using the admin client (service_role key, bypasses RLS)\n- **Display error messages**: login page now reads URL `?error=` params and shows user-friendly messages\n\n## Root Cause\n\nWhen users were created in `auth.users` but the `handle_new_user` trigger (migration 008) wasn't applied or failed silently, no row existed in `public.profiles`. The middleware's check `if (!profile || !profile.is_active)` triggered `signOut()` + redirect to `/login`, creating an infinite loop with no visible error.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `apps/links/src/middleware.ts` | Only sign out when `profile.is_active` is explicitly `false`; missing profile falls through with default role |\n| `packages/auth/src/provider.tsx` | Build fallback `UserSession` from auth metadata when profile is absent; trigger `/api/auth/ensure-profile` in background |\n| `apps/links/src/app/api/auth/ensure-profile/route.ts` | New route — creates missing profile using admin client |\n| `apps/links/src/app/login/page.tsx` | Parse `?error=` URL param and display alert banner |\n\n## Test plan\n\n- [ ] Login with a user that has a profile in `public.profiles` → redirects to dashboard (no regression)\n- [ ] Login with a user that has NO profile → redirects to dashboard, profile auto-created\n- [ ] Login with a user whose `is_active = false` → shows \"compte désactivé\" error on login page\n- [ ] Visit `/login?error=compte_desactive` directly → error banner displayed\n- [ ] Visit protected route while unauthenticated → redirects to `/login`\n\nhttps://claude.ai/code/session_01EE3ypLxJcVPirFwZoXtLX8"