### PR TITLE
fix(dashboard,auth): fix empty pages on dashboard navigation

### DIFF
--- a/packages/auth/src/hooks.ts
+++ b/packages/auth/src/hooks.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useContext, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { AuthContext, AuthConfigContext } from './provider'
 import { hasPermission } from './rbac'
 import type { AuthContextValue } from './types'
@@ -24,14 +25,15 @@ export function useAuthConfig() {
 export function useRequireRole(role: string | string[]) {
   const { user, isLoading } = useAuth()
   const config = useAuthConfig()
+  const router = useRouter()
   const roles = Array.isArray(role) ? role : [role]
 
   useEffect(() => {
     if (isLoading) return
     if (!user || !roles.includes(user.role)) {
-      window.location.href = config.redirects.unauthorized
+      router.replace(config.redirects.unauthorized)
     }
-  }, [user, isLoading, roles, config.redirects.unauthorized])
+  }, [user, isLoading, roles, config.redirects.unauthorized, router])
 
   return { isAuthorized: user ? roles.includes(user.role) : false, isLoading }
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -22,12 +22,14 @@
     "@unanima/eslint-config": "workspace:*",
     "@unanima/tsconfig": "workspace:*",
     "eslint": "^8.57.0",
+    "next": "^15.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.7.3",
     "vitest": "^1.6.1"
   },
   "peerDependencies": {
+    "next": "^14.0.0 || ^15.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   }

--- a/packages/dashboard/src/Layout.tsx
+++ b/packages/dashboard/src/Layout.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, type ReactNode } from 'react'
+import Link from 'next/link'
 import { cn } from '@unanima/core'
 
 export interface NavItem {
@@ -86,9 +87,10 @@ export function Layout({ sidebar, header, children, logoUrl, className }: Layout
           <ul className="flex flex-col gap-0.5">
             {sidebar.map((item) => (
               <li key={item.href}>
-                <a
+                <Link
                   href={item.href}
                   aria-current={item.active ? 'page' : undefined}
+                  onClick={() => setSidebarOpen(false)}
                   className={cn(
                     'flex items-center gap-3',
                     'rounded-[var(--radius-md,0.5rem)] px-3 py-2.5',
@@ -108,7 +110,7 @@ export function Layout({ sidebar, header, children, logoUrl, className }: Layout
                 >
                   {item.icon && <span className="h-5 w-5 shrink-0" aria-hidden="true">{item.icon}</span>}
                   {item.label}
-                </a>
+                </Link>
               </li>
             ))}
           </ul>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      next:
+        specifier: ^15.0.0
+        version: 15.5.14(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -4442,7 +4445,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -4472,7 +4475,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4487,7 +4490,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

- **Root cause**: Dashboard sidebar used plain HTML `<a href>` tags instead of Next.js `<Link>`, causing full page reloads on every click. This destroyed React state, forced AuthProvider to re-initialize from scratch, and showed empty pages/spinners while auth reloaded.
- Replace `<a>` with `next/link` `<Link>` in `packages/dashboard/src/Layout.tsx` for proper client-side navigation
- Replace `window.location.href` with `router.replace()` in `useRequireRole` hook to avoid full-page redirects
- Add `next` as peer/dev dependency for `@unanima/dashboard`

## Impact

All 3 apps (Links, CREAI, Omega) are fixed — the Layout component is in the shared `@unanima/dashboard` package.

## Test plan

- [ ] Login to any app, click sidebar links — pages load instantly without spinner flash
- [ ] Mobile: sidebar closes automatically after clicking a link
- [ ] Unauthorized role redirect still works (no `window.location.href` regression)
- [ ] `pnpm build` passes for all 3 apps (verified locally)

https://claude.ai/code/session_011wCi8D1tprukSkr9fmzdNf