### PR TITLE
fix(links): resolve login 500 error

### DIFF
--- a/apps/links/src/app/api/auth/login/route.ts
+++ b/apps/links/src/app/api/auth/login/route.ts
@@ -30,20 +30,18 @@ export async function POST(request: NextRequest) {
   const supabase = createAdminClient()
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null
 
-  // 1. Check if account is locked
+  // 1. Check if account is locked (graceful degradation: if RPC fails, skip lock check)
   const { data: lockCheck, error: lockError } = await supabase.rpc(
     'check_login_attempt',
     { attempt_email: normalizedEmail, max_attempts: MAX_ATTEMPTS, lockout_seconds: LOCKOUT_SECONDS }
   )
 
   if (lockError) {
-    return NextResponse.json(
-      { error: 'Erreur serveur. Réessayez plus tard.' },
-      { status: 500 }
-    )
+    console.error('[auth/login] check_login_attempt RPC failed:', lockError.message)
+    // Continue without brute-force protection rather than blocking all logins
   }
 
-  if (lockCheck?.locked) {
+  if (!lockError && lockCheck?.locked) {
     // Log the locked attempt
     await supabase.from('audit_logs').insert({
       user_id: null,


### PR DESCRIPTION
## Summary

- **Cause racine** : les migrations 006 (`rate_limits` table) et 009 (fonctions RPC `check_login_attempt`, `increment_login_failure`, `reset_login_attempts`) n'avaient jamais été appliquées sur le projet Supabase Links (`vtycrvrogvfvvdnknyem`). Le login route introduit au Sprint 9 appelle `check_login_attempt` RPC — qui échouait systématiquement → erreur 500 "Erreur serveur. Réessayez plus tard."
- **Fix DB** : migrations 006 et 009 appliquées directement sur le Supabase Links
- **Fix code** : dégradation gracieuse — si le RPC échoue, le login continue sans protection brute-force plutôt que de bloquer tous les utilisateurs

## Test plan

- [ ] Vérifier que le login fonctionne à nouveau sur l'app Links
- [ ] Vérifier que le verrouillage de compte après 3 tentatives échouées fonctionne
- [ ] Vérifier que le compteur se réinitialise après un login réussi

https://claude.ai/code/session_01FEXAg3qujyVU4cjJVrPxb5