### PR TITLE
fix(skills): connecter ergonomix et maquettix aux specs et maquettes projet

### DIFF
--- a/.claude/skills/_common/ui-spec-checklist.md
+++ b/.claude/skills/_common/ui-spec-checklist.md
@@ -1,0 +1,126 @@
+# Checklist UI — Consultation obligatoire des specs et maquettes
+
+Ce fichier est le point de référence commun pour les skills **ergonomix** et
+**maquettix**. Avant toute création ou modification d'écran, les deux skills
+DOIVENT suivre cette checklist.
+
+---
+
+## 1. Correspondance App → Specs → Maquettes → Wireframes
+
+| App | Specs fonctionnelles (SFD) | Maquettes SVG | Wireframes |
+|---|---|---|---|
+| **Links** | `docs/links/specs/SPC-0003-specifications-fonctionnelles-links-v1.0.md` | `docs/links/mockups/MAQ-*.svg` | `docs/links/specs/wireframes/wireframe-*.png` |
+| **CREAI** | `docs/creai/specs/` *(à compléter)* | `docs/creai/mockups/` *(à compléter)* | `docs/creai/specs/wireframes/` *(à compléter)* |
+| **Omega** | `docs/omega/specs/` *(à compléter)* | `docs/omega/mockups/` *(à compléter)* | `docs/omega/specs/wireframes/` *(à compléter)* |
+
+### Inventaire Links (à jour)
+
+**Maquettes SVG :**
+| Réf. | Écran | Fichier |
+|---|---|---|
+| MAQ-01 | Connexion | `docs/links/mockups/MAQ-01-login.svg` (+ v2) |
+| MAQ-02 | Dashboard bénéficiaire | `docs/links/mockups/MAQ-02-dashboard-beneficiaire.svg` |
+| MAQ-03 | Saisie de phase | `docs/links/mockups/MAQ-03-saisie-phase.svg` |
+| MAQ-04 | Dashboard consultant | `docs/links/mockups/MAQ-04-dashboard-consultant.svg` |
+| MAQ-05 | Fiche bénéficiaire (consultant) | `docs/links/mockups/MAQ-05-fiche-beneficiaire-consultant.svg` |
+| MAQ-06 | Comptes rendus | `docs/links/mockups/MAQ-06-comptes-rendus.svg` |
+| MAQ-07 | Dashboard admin | `docs/links/mockups/MAQ-07-dashboard-admin.svg` |
+| MAQ-08 | Gestion utilisateurs | `docs/links/mockups/MAQ-08-gestion-utilisateurs.svg` |
+| MAQ-09 | Planification | `docs/links/mockups/MAQ-09-planification.svg` |
+
+**Wireframes :**
+| Réf. | Écran | Fichier |
+|---|---|---|
+| WIR-01 | Connexion | `docs/links/specs/wireframes/wireframe-01-connexion.png` |
+| WIR-02 | Dashboard bénéficiaire | `docs/links/specs/wireframes/wireframe-02-dashboard-beneficiaire.png` |
+| WIR-03 | Saisie de phase | `docs/links/specs/wireframes/wireframe-03-saisie-phase.png` |
+| WIR-04 | Dashboard consultant | `docs/links/specs/wireframes/wireframe-04-dashboard-consultant.png` |
+| WIR-05 | Fiche bénéficiaire | `docs/links/specs/wireframes/wireframe-05-fiche-beneficiaire.png` |
+| WIR-06 | Dashboard admin | `docs/links/specs/wireframes/wireframe-06-dashboard-admin.png` |
+| WIR-07 | Comptes rendus | `docs/links/specs/wireframes/wireframe-07-comptes-rendus.png` |
+
+---
+
+## 2. Palette de couleurs par app
+
+> **Ne pas utiliser la palette générique UNANIMA.** Chaque app a sa propre
+> identité définie dans `apps/<app>/src/styles/theme.css` et dans la SFD.
+
+### Links (`apps/links/src/styles/theme.css` — SPC-0003 RT-04)
+
+| Rôle | Variable CSS | Couleur |
+|---|---|---|
+| Primary | `--color-primary` | `#1E6FC0` |
+| Primary dark | `--color-primary-dark` | `#0D3B6E` |
+| Secondary | `--color-secondary` | `#0EA5E9` |
+| Accent / Warning | `--color-accent` | `#FF6B35` |
+| Success | `--color-success` | `#28A745` |
+| Background | `--color-background` | `#F5F7FA` |
+| Text | `--color-text` | `#4A4A4A` |
+| Border | `--color-border` | `#DCE1EB` |
+| Font | `--font-family` | `Inter, sans-serif` |
+
+### CREAI (`apps/creai/src/styles/theme.css`)
+
+| Rôle | Variable CSS | Couleur |
+|---|---|---|
+| Primary | `--color-primary` | `#6D28D9` (violet) |
+| Primary dark | `--color-primary-dark` | `#4C1D95` |
+| Secondary | `--color-secondary` | `#0D9488` (teal) |
+| Accent | `--color-accent` | `#EC4899` (pink) |
+| Success | `--color-success` | `#059669` |
+| Background | `--color-background` | `#F5F3FF` |
+| Text | `--color-text` | `#1E1B4B` |
+| Border | `--color-border` | `#DDD6FE` |
+| Font | `--font-family` | `Source Sans 3, sans-serif` |
+
+### Omega (`apps/omega/src/styles/theme.css`)
+
+| Rôle | Variable CSS | Couleur |
+|---|---|---|
+| Primary | `--color-primary` | `#EA580C` (orange) |
+| Primary dark | `--color-primary-dark` | `#9A3412` |
+| Secondary | `--color-secondary` | `#334155` (slate) |
+| Accent | `--color-accent` | `#EAB308` (yellow) |
+| Success | `--color-success` | `#16A34A` |
+| Background | `--color-background` | `#F8FAFC` |
+| Text | `--color-text` | `#0F172A` |
+| Border | `--color-border` | `#CBD5E1` |
+| Font | `--font-family` | `DM Sans, sans-serif` |
+
+---
+
+## 3. Checklist obligatoire avant toute création/modification d'écran
+
+Avant de coder un composant UI ou de produire une maquette SVG :
+
+- [ ] **Identifier l'app cible** : Links, CREAI ou Omega
+- [ ] **Lire la SFD correspondante** : trouver la User Story et les règles de
+      gestion de l'écran dans la spécification fonctionnelle de l'app
+- [ ] **Consulter la maquette SVG** de l'écran cible (si existante) dans
+      `docs/<app>/mockups/`
+- [ ] **Consulter le wireframe** de l'écran cible (si existant) dans
+      `docs/<app>/specs/wireframes/`
+- [ ] **Vérifier la palette de couleurs** de l'app dans
+      `apps/<app>/src/styles/theme.css` — ne jamais utiliser la palette
+      générique UNANIMA par défaut
+- [ ] **Identifier les composants existants réutilisables** dans
+      `packages/core/src/components/` et `packages/dashboard/src/`
+- [ ] **Vérifier la cohérence** avec les écrans déjà implémentés de la même app
+
+---
+
+## 4. Règles d'utilisation
+
+1. **Ergonomix** : doit consulter cette checklist AVANT toute création ou
+   modification de composant UI. La SFD définit les données affichées, les
+   actions disponibles, les règles de validation et les rôles autorisés.
+
+2. **Maquettix** : doit consulter cette checklist AVANT toute génération de
+   SVG. La palette de l'app cible remplace la palette UNANIMA par défaut.
+   Les maquettes existantes définissent le style visuel de référence.
+
+3. **Si aucune SFD ou maquette n'existe** pour l'écran ciblé, le signaler
+   explicitement et proposer de créer la maquette en se basant sur la charte
+   visuelle de l'app (theme.css) et les conventions des écrans existants.

--- a/.claude/skills/ergonomix/SKILL.md
+++ b/.claude/skills/ergonomix/SKILL.md
@@ -16,7 +16,29 @@ Ce skill gouverne la conception et l'implémentation d'interfaces pour **applica
 
 ---
 
-## 0. Philosophie IHM Métier — À intérioriser
+## 0. Pré-requis — Consultation des specs et maquettes du projet
+
+> **OBLIGATOIRE** : Avant toute création ou modification d'écran, consulter
+> `_common/ui-spec-checklist.md` pour identifier la SFD (spécification
+> fonctionnelle) et la maquette SVG correspondantes à l'écran ciblé.
+> **Lire ces documents AVANT de commencer à coder.**
+
+### Étapes :
+1. Identifier l'app cible (Links, CREAI, Omega)
+2. Lire la checklist `_common/ui-spec-checklist.md`
+3. Ouvrir la SFD de l'app (ex : `docs/links/specs/SPC-0003-...`) et localiser
+   la User Story + les règles de gestion de l'écran
+4. Consulter la maquette SVG de l'écran dans `docs/<app>/mockups/`
+5. Vérifier la palette de couleurs dans `apps/<app>/src/styles/theme.css`
+6. Identifier les composants réutilisables existants (`packages/core/`,
+   `packages/dashboard/`)
+
+> Si aucune SFD ou maquette n'existe pour l'écran ciblé, le signaler
+> explicitement avant de procéder.
+
+---
+
+## 0b. Philosophie IHM Métier — À intérioriser
 
 > **"L'interface doit disparaître. Seule la tâche doit exister."**
 

--- a/.claude/skills/maquettix/SKILL.md
+++ b/.claude/skills/maquettix/SKILL.md
@@ -60,6 +60,12 @@ Ce skill applique les conventions de `_common/performance-workflow.md` :
 - **Scalabilité TypeScript** : les composants représentés doivent évoquer des composants React/Vue réutilisables
 
 ### Identité visuelle UNANIMA (défaut si pas de design system fourni)
+
+> **IMPORTANT** : Les apps Links, CREAI et Omega ont chacune leur propre
+> palette définie dans `apps/<app>/src/styles/theme.css` et dans la SFD.
+> Consulter `_common/ui-spec-checklist.md` pour les palettes exactes.
+> La palette UNANIMA ci-dessous ne s'applique que si aucune app n'est ciblée.
+
 - **Palette principale** : #0F172A (slate-900) fond sombre, #1E293B (slate-800) surfaces, #38BDF8 (sky-400) accent principal
 - **Palette alternative claire** : #F8FAFC fond, #F1F5F9 surfaces, #0EA5E9 accent
 - **Typographie** : `Inter` (UI), `JetBrains Mono` (données/code), `Geist` (titres)
@@ -67,17 +73,34 @@ Ce skill applique les conventions de `_common/performance-workflow.md` :
 - **Ombres** : subtiles, couches (0 1px 3px rgba(0,0,0,0.12), 0 4px 12px rgba(0,0,0,0.08))
 - **Grille** : 8px base unit, colonnes 12, gouttières 16-24px
 
+### Palettes par application (priorité sur la palette UNANIMA)
+| App | Primary | Primary Dark | Accent | Font |
+|---|---|---|---|---|
+| **Links** | `#1E6FC0` | `#0D3B6E` | `#FF6B35` | Inter |
+| **CREAI** | `#6D28D9` | `#4C1D95` | `#EC4899` | Source Sans 3 |
+| **Omega** | `#EA580C` | `#9A3412` | `#EAB308` | DM Sans |
+
 ---
 
 ## 2. Workflow de Création
 
 ### Étape 1 — Analyse du besoin (TOUJOURS faire cette étape)
+
+> **OBLIGATOIRE** : Avant de générer le SVG, consulter
+> `_common/ui-spec-checklist.md` pour identifier la SFD et la maquette
+> existante de l'écran ciblé. Si une maquette existe déjà (ex : MAQ-01 à
+> MAQ-09 pour Links), s'en inspirer pour la cohérence visuelle. Si une SFD
+> existe (ex : SPC-0003 pour Links), y lire les données affichées, les
+> actions disponibles et les règles de gestion.
+
 Avant de générer le SVG, déduire ou demander :
 1. **Type d'écran** : liste/tableau, formulaire, dashboard, détail fiche, wizard, modal, etc.
 2. **Contexte métier** : module fonctionnel, type d'utilisateur, criticité des données
 3. **Format cible** : dimensions souhaitées (défaut : 1440×900px), orientation
 4. **Intégration** : destination (doc Word, PDF rapport, présentation, wiki)
 5. **Design system existant** : couleurs, typographie, composants déjà définis ?
+6. **Specs et maquettes existantes** : consulter `_common/ui-spec-checklist.md`
+   pour la correspondance écran → SFD → maquette → wireframe
 
 ### Étape 2 — Choix du pattern de layout
 


### PR DESCRIPTION
## Résumé

- Crée `_common/ui-spec-checklist.md` : référentiel commun centralisant la correspondance app → SFD → maquettes → wireframes, les palettes de couleurs par app (Links/CREAI/Omega), et une checklist obligatoire avant toute création/modification d'écran
- Ajoute une **étape 0 obligatoire** dans `ergonomix/SKILL.md` imposant la consultation des specs et maquettes existantes avant tout codage UI
- Enrichit l'**étape 1** de `maquettix/SKILL.md` avec l'instruction de lire les specs existantes et ajoute un tableau des palettes par app, précisant que la palette UNANIMA par défaut ne s'applique que si aucune app n'est ciblée

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `.claude/skills/_common/ui-spec-checklist.md` | Créé — référentiel commun specs/maquettes/palettes |
| `.claude/skills/ergonomix/SKILL.md` | Ajout étape 0 obligatoire (consultation specs/maquettes) |
| `.claude/skills/maquettix/SKILL.md` | Ajout lecture specs en étape 1 + tableau palettes par app |

## Critère d'acceptation

Après cette modification, invoquer ergonomix ou maquettix sur un écran Links déclenche automatiquement la lecture de la SFD (SPC-0003) et de la maquette correspondante (MAQ-01 à MAQ-09) AVANT toute génération de code ou de SVG.

Fixes #167