### PR TITLE
fix(links): corriger les écarts visuels des écrans existants vs maquettes

### DIFF
--- a/apps/links/src/app/(protected)/bilans/[id]/page.tsx
+++ b/apps/links/src/app/(protected)/bilans/[id]/page.tsx
@@ -342,10 +342,15 @@ export default function PhaseDetailPage() {
           {questions.map((question, index) => (
             <Card key={question.id} padding="md">
               <label className="block">
-                <span className="text-sm font-medium text-[var(--color-text)]">
-                  Question {index + 1} / {questions.length}
-                </span>
-                <p className="mt-1 text-sm text-[var(--color-text)]">{question.text}</p>
+                <div className="flex items-center gap-3">
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-bold text-[var(--color-text-inverse)]">
+                    {index + 1}
+                  </span>
+                  <span className="text-sm font-medium text-[var(--color-text)]">
+                    Question {index + 1} / {questions.length}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-[var(--color-text)]">{question.text}</p>
                 <Textarea
                   value={responses[question.id] ?? ''}
                   onChange={(e) => handleChange(question.id, e.target.value)}

--- a/apps/links/src/app/(protected)/dashboard/page.tsx
+++ b/apps/links/src/app/(protected)/dashboard/page.tsx
@@ -21,7 +21,7 @@ const PHASE_LABELS: Record<number, string> = {
 
 const PHASE_STATUS_CONFIG = {
   libre: { label: 'À compléter', color: 'info' as const },
-  en_cours: { label: 'En cours', color: 'primary' as const },
+  en_cours: { label: 'En cours', color: 'warning' as const },
   validee: { label: 'Validé', color: 'success' as const },
 }
 
@@ -293,7 +293,7 @@ export default function DashboardPage() {
       </section>
 
       {/* ═══ PHASE CARDS GRID (MAQ-02: 3×2) ═══ */}
-      <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-[30px] sm:grid-cols-2 lg:grid-cols-3">
         {allPhases.map((phase) => {
           const isValidee = phase.status === 'validee'
           const isEnCours = phase.status === 'en_cours'
@@ -320,7 +320,7 @@ export default function DashboardPage() {
           return (
             <div
               key={phase.phase_number}
-              className={`relative overflow-hidden rounded-[var(--radius-lg)] border bg-[var(--color-surface)] p-4 transition-shadow hover:shadow-md ${borderColor}`}
+              className={`relative min-h-[110px] overflow-hidden rounded-[var(--radius-lg)] border bg-[var(--color-surface)] p-4 transition-shadow hover:shadow-md ${borderColor}`}
             >
               {/* Left accent bar */}
               <div
@@ -342,10 +342,20 @@ export default function DashboardPage() {
                 </div>
 
                 {/* Status badge */}
-                <StatusBadge
-                  status={phase.status}
-                  statusConfig={PHASE_STATUS_CONFIG}
-                />
+                {isEnCours ? (
+                  <span className="inline-flex items-center gap-1.5 rounded-[var(--radius-full,9999px)] px-2.5 py-0.5 text-xs font-medium bg-[var(--color-warning-light)] text-[var(--color-warning)] ring-1 ring-inset ring-[var(--color-warning)]/20">
+                    <span className="relative flex h-2 w-2">
+                      <span className="animate-pulse-dot absolute inline-flex h-full w-full rounded-full bg-[var(--color-warning)]" />
+                      <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--color-warning)]" />
+                    </span>
+                    En cours
+                  </span>
+                ) : (
+                  <StatusBadge
+                    status={phase.status}
+                    statusConfig={PHASE_STATUS_CONFIG}
+                  />
+                )}
 
                 {/* Action button */}
                 {isLibre ? (

--- a/apps/links/src/app/globals.css
+++ b/apps/links/src/app/globals.css
@@ -22,3 +22,13 @@
     outline-offset: 2px;
   }
 }
+
+/* Animation point pulsant — état "En cours" (MAQ-02) */
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(1.8); }
+}
+
+.animate-pulse-dot {
+  animation: pulse-dot 2s ease-in-out infinite;
+}


### PR DESCRIPTION
## Résumé

Correction des écarts visuels identifiés entre les maquettes SVG (MAQ-01, MAQ-02, MAQ-03) et les écrans implémentés de l'application Link's.

### Corrections apportées

| Écran | Correction | Justification |
|---|---|---|
| Dashboard | Grille phases : gap 20px → 30px | MAQ-02 spécifie gap 30px entre cartes 280×110 |
| Dashboard | StatusBadge "En cours" : bleu → orange | MAQ-02 utilise #FF6B35 (orange) pour l'état "En cours" |
| Dashboard | Animation point pulsant orange | MAQ-02 montre un dot pulsant sur le badge "En cours" |
| Dashboard | Min-height 110px sur cartes de phase | MAQ-02 spécifie 280×110px par carte |
| Saisie de phase | Badge numéroté circulaire bleu | MAQ-03 montre un cercle bleu avec le numéro devant chaque question |

### Écran Login (MAQ-01-v2)
Aucun écart significatif identifié — l'implémentation est conforme à la maquette.

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `apps/links/src/app/globals.css` | Ajout animation CSS `pulse-dot` |
| `apps/links/src/app/(protected)/dashboard/page.tsx` | Gap grille, couleur badge, animation, min-height |
| `apps/links/src/app/(protected)/bilans/[id]/page.tsx` | Badge numéroté circulaire questions |

## Validation

- ✅ Lint (warnings pré-existantes uniquement)
- ✅ Tests (114/114 passés)
- ✅ Build réussi

Fixes #170