### PR TITLE
fix(auth): resolve login redirect loop caused by httpOnly cookie override

### DIFF
--- a/apps/links/src/app/login/page.tsx
+++ b/apps/links/src/app/login/page.tsx
@@ -56,10 +56,10 @@ export default function LoginPage() {
 
   useEffect(() => {
     if (!isLoading && user) {
-      const dest = ROLE_HOME[user.role] ?? '/dashboard'
+      const dest = redirectPath ?? ROLE_HOME[user.role] ?? '/dashboard'
       router.replace(dest)
     }
-  }, [user, isLoading, router])
+  }, [user, isLoading, router, redirectPath])
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -88,13 +88,19 @@ export default function LoginPage() {
           process.env.NEXT_PUBLIC_SUPABASE_URL!,
           process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
         )
-        await supabase.auth.setSession({
+        const { error: sessionError } = await supabase.auth.setSession({
           access_token: data.session.access_token,
           refresh_token: data.session.refresh_token,
         })
 
-        const dest = redirectPath ?? ROLE_HOME[data.role ?? 'beneficiaire'] ?? '/dashboard'
-        router.replace(dest)
+        if (sessionError) {
+          setError("Erreur lors de l'établissement de la session.")
+          setIsSubmitting(false)
+          return
+        }
+
+        // La navigation est gérée par le useEffect qui surveille `user`
+        // (déclenché par onAuthStateChange après setSession)
       }
     } catch {
       setError('Erreur réseau. Vérifiez votre connexion.')

--- a/apps/links/src/middleware.ts
+++ b/apps/links/src/middleware.ts
@@ -107,12 +107,7 @@ export default async function middleware(request: NextRequest) {
           request: { headers: request.headers },
         })
         cookiesToSet.forEach(({ name, value, options }) =>
-          response.cookies.set(name, value, {
-            ...options,
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production',
-            sameSite: 'strict',
-          }),
+          response.cookies.set(name, value, options ?? {}),
         )
       },
     },

--- a/packages/auth/src/components/login-form.tsx
+++ b/packages/auth/src/components/login-form.tsx
@@ -63,10 +63,10 @@ export function LoginForm({ config, errorMessages, onResetPassword, className }:
 
   useEffect(() => {
     if (!isLoading && user) {
-      const dest = config.roleRedirects?.[user.role] ?? defaultRedirect ?? '/dashboard'
+      const dest = redirectPath ?? config.roleRedirects?.[user.role] ?? defaultRedirect ?? '/dashboard'
       router.replace(dest)
     }
-  }, [user, isLoading, router, config.roleRedirects, defaultRedirect])
+  }, [user, isLoading, router, redirectPath, config.roleRedirects, defaultRedirect])
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -97,17 +97,19 @@ export function LoginForm({ config, errorMessages, onResetPassword, className }:
           process.env.NEXT_PUBLIC_SUPABASE_URL!,
           process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
         )
-        await supabase.auth.setSession({
+        const { error: sessionError } = await supabase.auth.setSession({
           access_token: data.session.access_token,
           refresh_token: data.session.refresh_token,
         })
 
-        const dest =
-          redirectPath ??
-          config.roleRedirects?.[data.role ?? ''] ??
-          defaultRedirect ??
-          '/dashboard'
-        router.replace(dest)
+        if (sessionError) {
+          setError("Erreur lors de l'établissement de la session.")
+          setIsSubmitting(false)
+          return
+        }
+
+        // La navigation est gérée par le useEffect qui surveille `user`
+        // (déclenché par onAuthStateChange après setSession)
       }
     } catch {
       setError('Erreur réseau. Vérifiez votre connexion.')


### PR DESCRIPTION
## Résumé

Corrige la boucle infinie d'authentification sur Links (#181) : après login réussi, l'utilisateur était redirigé en boucle vers `/login` sans message d'erreur.

**Cause racine** : Le middleware écrasait les options de cookies Supabase SSR avec `httpOnly: true` et `sameSite: 'strict'`. Après un refresh de token par le middleware, le client navigateur Supabase ne pouvait plus lire les cookies d'auth → `AuthProvider` signalait `user: null` → `useRequireRole` redirigeait vers `/login`.

**Corrections :**
- **Middleware** (`apps/links/src/middleware.ts`) : passe les options Supabase telles quelles, sans override `httpOnly`/`sameSite`
- **Login page Links** (`apps/links/src/app/login/page.tsx`) : vérifie les erreurs de `setSession()`, supprime le `router.replace` concurrent (navigation déléguée au `useEffect` existant), intègre `redirectPath` dans le `useEffect`
- **LoginForm partagé** (`packages/auth/src/components/login-form.tsx`) : même correction pour CREAI et Omega

## Fichiers modifiés

| Fichier | Modification |
|---------|-------------|
| `apps/links/src/middleware.ts` | Suppression override `httpOnly: true`, `sameSite: 'strict'` sur les cookies Supabase |
| `apps/links/src/app/login/page.tsx` | Gestion erreur `setSession`, navigation via `useEffect` uniquement |
| `packages/auth/src/components/login-form.tsx` | Idem (composant partagé) |

## Validation

- [x] Lint ✅
- [x] Tests (170 + 29) ✅
- [x] Build ✅

Fixes #181